### PR TITLE
Set Swift Quotas

### DIFF
--- a/ci/devstack.sh
+++ b/ci/devstack.sh
@@ -3,7 +3,8 @@
 #
 set -xe
 
-sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get update
+# sudo apt-get upgrade -y
 
 sudo mkdir -p /opt/stack
 sudo chown "$USER:$USER" /opt/stack
@@ -19,7 +20,7 @@ source /opt/stack/devstack-plugin-oidc/tools/config.sh
 cd /opt/stack/devstack-plugin-oidc/tools && sudo docker-compose up -d
 
 # Install and start Devstack
-git clone https://opendev.org/openstack/devstack.git /opt/stack/devstack
+git clone https://github.com/openstack/devstack.git /opt/stack/devstack
 cd /opt/stack/devstack
 
 cp samples/local.conf .
@@ -29,18 +30,30 @@ if [[ "${CI}" == "true" ]]; then
     sudo systemctl start mysql
 
     echo "
-        disable_service horizon
-        disable_service tempest
         INSTALL_DATABASE_SERVER_PACKAGES=False
         DATABASE_PASSWORD=root
     " >> local.conf
 fi
 
 echo "
+    disable_service horizon
+    disable_service tempest
+    enable_service s-proxy s-object s-container s-account
+    SWIFT_REPLICAS=1
     IP_VERSION=4
+    GIT_DEPTH=1
+    GIT_BASE=https://github.com
     KEYSTONE_ADMIN_ENDPOINT=True
     enable_plugin devstack-plugin-oidc https://github.com/knikolla/devstack-plugin-oidc main
+
+    SWIFT_DEFAULT_BIND_PORT=8085
+    SWIFT_DEFAULT_BIND_PORT_INT=8086
 " >> local.conf
 ./stack.sh
 
 python3 /opt/stack/devstack-plugin-oidc/tools/test_login.py
+
+source /opt/stack/devstack/openrc admin admin
+
+# Create role implication to allow admin to admin on Swift
+openstack implied role create admin --implied-role ResellerAdmin

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-keystoneclient
 python-memcached==1.59
 python-novaclient
 python-neutronclient
+python-swiftclient

--- a/src/coldfront_plugin_openstack/attributes.py
+++ b/src/coldfront_plugin_openstack/attributes.py
@@ -31,10 +31,13 @@ QUOTA_VOLUMES_GB = 'OpenStack Volume GB Quota'
 
 QUOTA_FLOATING_IPS = 'OpenStack Floating IP Quota'
 
+QUOTA_OBJECT_GB = 'OpenStack Swift Quota in Gigabytes'
+
 ALLOCATION_QUOTA_ATTRIBUTES = [QUOTA_INSTANCES,
                                QUOTA_RAM,
                                QUOTA_VCPU,
                                QUOTA_VOLUMES,
                                QUOTA_VOLUMES_GB,
-                               QUOTA_FLOATING_IPS,]
+                               QUOTA_FLOATING_IPS,
+                               QUOTA_OBJECT_GB]
 

--- a/src/coldfront_plugin_openstack/openstack.py
+++ b/src/coldfront_plugin_openstack/openstack.py
@@ -3,6 +3,7 @@ import logging
 import os
 import urllib.parse
 
+import swiftclient
 from keystoneauth1.identity import v3
 from keystoneauth1 import session
 from keystoneauth1 import exceptions as ksa_exceptions
@@ -20,8 +21,6 @@ logger = logging.getLogger(__name__)
 # service, the version of the API, and the key in the payload.
 QUOTA_KEY_MAPPING = {
     'compute': {
-        'class': novaclient.Client,
-        'version': 2,
         'keys': {
             attributes.QUOTA_INSTANCES: 'instances',
             attributes.QUOTA_VCPU: 'cores',
@@ -29,15 +28,16 @@ QUOTA_KEY_MAPPING = {
         },
     },
     'network': {
-        'class': neutronclient.Client,
-        'version': None,
         'keys': {
-            attributes.QUOTA_FLOATING_IPS: 'floatingip'
+            attributes.QUOTA_FLOATING_IPS: 'floatingip',
+        }
+    },
+    'object': {
+        'keys': {
+            attributes.QUOTA_OBJECT_GB: 'X-Account-Meta-Quota-Bytes',
         }
     },
     'volume': {
-        'class': cinderclient.Client,
-        'version': 3,
         'keys': {
             attributes.QUOTA_VOLUMES: 'volumes',
             attributes.QUOTA_VOLUMES_GB: 'gigabytes',
@@ -95,27 +95,48 @@ class OpenStackResourceAllocator(base.ResourceAllocator):
         self.identity.projects.update(project_id, enabled=False)
 
     def set_quota(self, project_id):
+        session = get_session_for_resource(self.resource)
         # If an attribute with the appropriate name is associated with an
         # allocation, set that as the quota. Otherwise, multiply
         # the quantity attribute via the mapping table above.
         for service_name, service in QUOTA_KEY_MAPPING.items():
-            client = service['class'](
-                version=service['version'],
-                session=get_session_for_resource(self.resource)
-            )
-
             # No need to do any calculations here, just go through each service
             # and set the value in the attribute.
             payload = dict()
             for coldfront_attr, openstack_key in service['keys'].items():
-                payload[openstack_key] = self.allocation.get_attribute(coldfront_attr)
+                if value := self.allocation.get_attribute(coldfront_attr):
+                    payload[openstack_key] = value
 
             if service_name == 'network':
-                # The neutronclient call for quotas is slightly different
-                # from how the other clients do it.
+                client = neutronclient.Client(session=session)
                 client.update_quota(project_id, body={'quota': payload})
-            else:
+            elif service_name == 'volume':
+                client = cinderclient.Client(session=session, version=3)
                 client.quotas.update(project_id, **payload)
+            elif service_name == 'compute':
+                client = novaclient.Client(session=session, version=2)
+                client.quotas.update(project_id, **payload)
+            elif service_name == 'object':
+                try:
+                    # If you want to perform operation on a project different
+                    # from the one you authenticated as, you must specify the
+                    # endpoint manually. Endpoint url is in the form:
+                    # "http://172.16.109.217:8085/v1/AUTH_$(project_id)s"
+                    swift_service = self.identity.services.find(name='swift')
+                    url = self.identity.endpoints.list(service=swift_service,
+                                                       interface='public')[0].url
+                    url = url.replace('$(project_id)s', project_id)
+
+                    client = swiftclient.Connection(session=session,
+                                                    preauthurl=url)
+                    # Note(knikolla): For consistency with other OpenStack quotas
+                    # we're storing this as GB on the attribute and then
+                    # converting to bytes for Swift.
+                    # 1 GB = 1 000 000 000 B = 10^9 B
+                    payload['X-Account-Meta-Quota-Bytes'] *= 1000000000
+                    client.post_account(headers=payload)
+                except ksa_exceptions.NotFound:
+                    logger.debug('No swift available, skipping its quota.')
 
     def get_user_payload_for_resource(self, username):
         domain_id = self.resource.get_attribute(attributes.RESOURCE_USER_DOMAIN)

--- a/src/coldfront_plugin_openstack/tasks.py
+++ b/src/coldfront_plugin_openstack/tasks.py
@@ -21,6 +21,7 @@ UNIT_QUOTA_MULTIPLIERS = {
         attributes.QUOTA_VOLUMES: 2,
         attributes.QUOTA_VOLUMES_GB: 100,
         attributes.QUOTA_FLOATING_IPS: 0,
+        attributes.QUOTA_OBJECT_GB: 1,
     }
 }
 

--- a/src/coldfront_plugin_openstack/tests/functional/test_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/functional/test_allocation.py
@@ -21,14 +21,8 @@ class TestAllocation(base.TestBase):
                                           auth_url=os.getenv('OS_AUTH_URL'))
         self.session = openstack.get_session_for_resource(self.resource)
         self.identity = client.Client(session=self.session)
-        self.compute = novaclient.Client(
-            openstack.QUOTA_KEY_MAPPING['compute']['version'],
-            session=self.session
-        )
-        self.volume = cinderclient.Client(
-            openstack.QUOTA_KEY_MAPPING['volume']['version'],
-            session=self.session
-        )
+        self.compute = novaclient.Client(session=self.session, version=2)
+        self.volume = cinderclient.Client(session=self.session, version=3)
         self.networking = neutronclient.Client(session=self.session)
         self.role_member = self.identity.roles.find(name='member')
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ python-keystoneclient
 python-memcached==1.59
 python-novaclient
 python-neutronclient
+python-swiftclient


### PR DESCRIPTION
This PR adds a new attribute for quotas 'OpenStack Swift Quota in Gigabytes' and adds the logic to set the quota on Swift. Requires the `account-quotas` middleware in the swift proxy pipeline. 