### PR TITLE
Rename attributes to remove OpenStack prefix

### DIFF
--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -1,8 +1,9 @@
-RESOURCE_AUTH_URL = 'OpenStack Auth URL'  # TODO: remove OpenStack prefix
+RESOURCE_AUTH_URL = 'Identity Endpoint URL'
+RESOURCE_ROLE = 'Role for User in Project'
+
 RESOURCE_FEDERATION_PROTOCOL = 'OpenStack Federation Protocol'
 RESOURCE_IDP = 'OpenStack Identity Provider'
 RESOURCE_PROJECT_DOMAIN = 'OpenStack Domain for Projects'
-RESOURCE_ROLE = 'OpenStack Role for User in Project'
 RESOURCE_USER_DOMAIN = 'OpenStack Domain for Users'
 RESOURCE_DEFAULT_PUBLIC_NETWORK = 'OpenStack Public Network ID'
 RESOURCE_DEFAULT_NETWORK_CIDR = 'OpenStack Default Network CIDR'
@@ -20,8 +21,8 @@ RESOURCE_ATTRIBUTES = [RESOURCE_AUTH_URL,
                        RESOURCE_DEFAULT_NETWORK_CIDR]
 
 # TODO: Migration to rename the OpenStack specific prefix out of these attrs
-ALLOCATION_PROJECT_ID = 'OpenStack Project ID'
-ALLOCATION_PROJECT_NAME = 'OpenStack Project Name'
+ALLOCATION_PROJECT_ID = 'Allocated Project ID'
+ALLOCATION_PROJECT_NAME = 'Allocated Project Name'
 
 ALLOCATION_ATTRIBUTES = [ALLOCATION_PROJECT_ID,
                          ALLOCATION_PROJECT_NAME]

--- a/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
+++ b/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
@@ -16,10 +16,18 @@ ALLOCATION_ATTRIBUTE_MIGRATIONS = [
         'is_private': False,
         'is_changeable': False,
     }),
+    ('OpenStack Project ID', {
+        'name': 'Allocated Project ID'
+    }),
+    ('OpenStack Project Name', {
+        'name': 'Allocated Project Name'
+    }),
 ]
 
 RESOURCE_ATTRIBUTE_MIGRATIONS = [
     ('Example old attribute name', 'Example new attribute name'),
+    ('OpenStack Auth URL', 'Identity Endpoint URL'),
+    ('OpenStack Role for User in Project', 'Role for User in Project'),
 ]
 
 


### PR DESCRIPTION
The following Resource attributes are migrated
- OpenStack Auth URL -> Identity Endpoint URL
- OpenStack Role for User in Project -> Role for User in Project

The following Allocation attributes are migrated
- OpenStack Project Name -> Allocated Project Name
- OpenStack Project ID -> Allocated Project ID

The choice of allocated is to signal that the allocation has
been completed on the service.

Additionaly, a test has been added to verify that the migration
of resource attributes preserves the value of the attribute.

Closes #59 