### PR TITLE
Add support for setting storage and pvc quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ following resource allocation attribute types.
 * OpenShift Limit on CPU Quota
 * OpenShift Limit on RAM Quota
 * OpenShift Limit on Ephemeral Storage Quota (GB)
+* OpenShift Request on Storage Quota (GB)
+* OpenShift Persistent Volume Quota
 
 By submitting a Resource Allocation Change Request and editing those attributes
 a PI can request a change in their quota.

--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -47,6 +47,9 @@ QUOTA_GPU = 'OpenStack GPU Quota'
 QUOTA_LIMITS_CPU = 'OpenShift Limit on CPU Quota'
 QUOTA_LIMITS_MEMORY = 'OpenShift Limit on RAM Quota'
 QUOTA_LIMITS_EPHEMERAL_STORAGE_GB = 'OpenShift Limit on Ephemeral Storage Quota (GB)'
+QUOTA_REQUESTS_STORAGE = 'OpenShift Request on Storage Quota (GB)'
+QUOTA_PVC = 'OpenShift Persistent Volume Claims Quota'
+
 
 ALLOCATION_QUOTA_ATTRIBUTES = [QUOTA_INSTANCES,
                                QUOTA_RAM,
@@ -58,4 +61,6 @@ ALLOCATION_QUOTA_ATTRIBUTES = [QUOTA_INSTANCES,
                                QUOTA_GPU,
                                QUOTA_LIMITS_CPU,
                                QUOTA_LIMITS_MEMORY,
-                               QUOTA_LIMITS_EPHEMERAL_STORAGE_GB]
+                               QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
+                               QUOTA_REQUESTS_STORAGE,
+                               QUOTA_PVC]

--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -13,6 +13,8 @@ QUOTA_KEY_MAPPING = {
     attributes.QUOTA_LIMITS_CPU: lambda x: {":limits.cpu": f"{x * 1000}m"},
     attributes.QUOTA_LIMITS_MEMORY: lambda x: {":limits.memory": f"{x}Mi"},
     attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB: lambda x: {":limits.ephemeral-storage": f"{x}Gi"},
+    attributes.QUOTA_REQUESTS_STORAGE: lambda x: {":requests.storage": f"{x}Gi"},
+    attributes.QUOTA_PVC: lambda x: {":persistentvolumeclaims": f"{x}"},
 }
 
 

--- a/src/coldfront_plugin_cloud/tasks.py
+++ b/src/coldfront_plugin_cloud/tasks.py
@@ -32,6 +32,8 @@ UNIT_QUOTA_MULTIPLIERS = {
         attributes.QUOTA_LIMITS_CPU: 2,
         attributes.QUOTA_LIMITS_MEMORY: 2048,
         attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB: 5,
+        attributes.QUOTA_REQUESTS_STORAGE: 10,
+        attributes.QUOTA_PVC: 2
     }
 }
 

--- a/src/coldfront_plugin_cloud/tests/functional/openshift/test_allocation.py
+++ b/src/coldfront_plugin_cloud/tests/functional/openshift/test_allocation.py
@@ -98,6 +98,8 @@ class TestAllocation(base.TestBase):
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_CPU), 2 * 2)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_MEMORY), 2 * 2048)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB), 2 * 5)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_STORAGE), 2 * 10)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_PVC), 2 * 2)
 
         quota = allocator.get_quota(project_id)['Quota']
         quota = {k: v for k, v in quota.items() if v is not None}
@@ -107,16 +109,22 @@ class TestAllocation(base.TestBase):
             ":limits.cpu": "4",
             ":limits.memory": "4Gi",
             ":limits.ephemeral-storage": "10Gi",
+            ":requests.storage": "20Gi",
+            ":persistentvolumeclaims": "4",
         })
 
         # change a bunch of attributes
         utils.set_attribute_on_allocation(allocation, attributes.QUOTA_LIMITS_CPU, 6)
         utils.set_attribute_on_allocation(allocation, attributes.QUOTA_LIMITS_MEMORY, 8192)
         utils.set_attribute_on_allocation(allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 50)
+        utils.set_attribute_on_allocation(allocation, attributes.QUOTA_REQUESTS_STORAGE, 100)
+        utils.set_attribute_on_allocation(allocation, attributes.QUOTA_PVC, 10)
 
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_CPU), 6)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_MEMORY), 8192)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB), 50)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_STORAGE), 100)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_PVC), 10)
 
         # This call should update the openshift quota to match the current attributes
         call_command('validate_allocations', apply=True)
@@ -128,6 +136,8 @@ class TestAllocation(base.TestBase):
             ":limits.cpu": "6",
             ":limits.memory": "8Gi",
             ":limits.ephemeral-storage": "50Gi",
+            ":requests.storage": "100Gi",
+            ":persistentvolumeclaims": "10",
         })
 
     def test_reactivate_allocation(self):
@@ -154,6 +164,8 @@ class TestAllocation(base.TestBase):
             ":limits.cpu": "4",
             ":limits.memory": "4Gi",
             ":limits.ephemeral-storage": "10Gi",
+            ":requests.storage": "20Gi",
+            ":persistentvolumeclaims": "4",
         })
 
         # Simulate an attribute change request and subsequent approval which
@@ -170,6 +182,8 @@ class TestAllocation(base.TestBase):
             ":limits.cpu": "3",
             ":limits.memory": "4Gi",
             ":limits.ephemeral-storage": "10Gi",
+            ":requests.storage": "20Gi",
+            ":persistentvolumeclaims": "4",
         })
 
         allocator._get_role(user.username, project_id)


### PR DESCRIPTION
Adds support for
- limits
- persistentvolumeclaims

Sets the defaults to 10Gi storage and 2 volumes.

Closes #78