### PR TITLE
Update pip package in CI setup

### DIFF
--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -6,5 +6,6 @@ if [[ ! "${CI}" == "true" ]]; then
     source /tmp/coldfront_venv/bin/activate
 fi
 
+python -m pip install --upgrade pip
 pip3 install -r test-requirements.txt
 pip3 install -e .


### PR DESCRIPTION
An update to `setuptools` broke `pip`. This updates `pip` to pick up the fix, and in turn fix our CI. 