### PR TITLE
Include Coldfront project name when generating project display name

### DIFF
--- a/src/coldfront_plugin_cloud/base.py
+++ b/src/coldfront_plugin_cloud/base.py
@@ -1,5 +1,6 @@
 import abc
 import functools
+from typing import NamedTuple
 
 from coldfront.core.allocation import models as allocation_models
 from coldfront.core.resource import models as resource_models
@@ -12,6 +13,10 @@ class ResourceAllocator(abc.ABC):
     resource_type = ''
 
     project_name_max_length = None
+
+    class Project(NamedTuple):
+        name: str
+        id: str
 
     def __init__(self,
                  resource: resource_models.Resource,
@@ -33,7 +38,7 @@ class ResourceAllocator(abc.ABC):
         return self.resource.get_attribute(attributes.RESOURCE_ROLE) or 'member'
 
     @abc.abstractmethod
-    def create_project(self, project_name) -> str:
+    def create_project(self, suggested_project_name) -> Project:
         pass
 
     @abc.abstractmethod

--- a/src/coldfront_plugin_cloud/openstack.py
+++ b/src/coldfront_plugin_cloud/openstack.py
@@ -119,13 +119,17 @@ class OpenStackResourceAllocator(base.ResourceAllocator):
             preauthurl=preauth_url,
         )
 
-    def create_project(self, project_name) -> str:
+    def create_project(self, suggested_project_name) -> base.ResourceAllocator.Project:
+        project_name = utils.get_unique_project_name(
+            suggested_project_name,
+            max_length=self.project_name_max_length)
+
         openstack_project = self.identity.projects.create(
             name=project_name,
             domain=self.resource.get_attribute(attributes.RESOURCE_PROJECT_DOMAIN),
             enabled=True,
         )
-        return openstack_project.id
+        return self.Project(project_name, openstack_project.id)
 
     def reactivate_project(self, project_id):
         openstack_project = self.identity.projects.get(project_id)

--- a/src/coldfront_plugin_cloud/tasks.py
+++ b/src/coldfront_plugin_cloud/tasks.py
@@ -60,12 +60,6 @@ def find_allocator(allocation) -> base.ResourceAllocator:
         return allocator_class(resource, allocation)
 
 
-def get_unique_project_name(project_name, max_length=None):
-    # The random hex at the end of the project name is 6 chars, 1 hyphen
-    max_without_suffix = max_length - 7 if max_length else None
-    return f'{project_name[:max_without_suffix]}-f{secrets.token_hex(3)}'
-
-
 def activate_allocation(allocation_pk):
     def set_quota_attributes():
         if allocation.quantity < 1:
@@ -88,11 +82,10 @@ def activate_allocation(allocation_pk):
         if project_id := allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID):
             allocator.reactivate_project(project_id)
         else:
-            project_name = get_unique_project_name(
-                allocation.project.title,
-                max_length=allocator.project_name_max_length
-            )
-            project_id = allocator.create_project(project_name)
+            project = allocator.create_project(allocation.project.title)
+
+            project_id = project.id
+            project_name = project.name
 
             utils.set_attribute_on_allocation(allocation,
                                               attributes.ALLOCATION_PROJECT_NAME,

--- a/src/coldfront_plugin_cloud/tests/unit/test_utils.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_utils.py
@@ -1,0 +1,10 @@
+import re
+from coldfront_plugin_cloud.tests import base
+from coldfront_plugin_cloud import utils
+
+class TestGetSanitizedProjectName(base.TestBase):
+    def test_project_name(self):
+        # Ensure that the sanitized project name conforms to DNS 1123 spec (besides the max length)
+        project_name = "---TEST - Software & Application Innovation Lab (SAIL) - TEST Projects   "
+        sanitized_name = utils.get_sanitized_project_name(project_name)
+        self.assertTrue(re.match(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", sanitized_name))

--- a/src/coldfront_plugin_cloud/utils.py
+++ b/src/coldfront_plugin_cloud/utils.py
@@ -1,3 +1,5 @@
+import re
+import secrets
 from coldfront.core.allocation.models import (AllocationAttribute,
                                               AllocationAttributeType)
 
@@ -22,3 +24,22 @@ def set_attribute_on_allocation(allocation, attribute_type, attribute_value):
             allocation=allocation,
             value=attribute_value,
         )
+
+def get_unique_project_name(project_name, max_length=None):
+    # The random hex at the end of the project name is 6 chars, 1 hyphen
+    max_without_suffix = max_length - 7 if max_length else None
+    return f'{project_name[:max_without_suffix]}-f{secrets.token_hex(3)}'
+
+def get_sanitized_project_name(project_name):
+    '''
+    Returns a sanitized project name that only contains lowercase
+    alphanumeric characters and dashes (not leading or trailing.)
+    '''
+    project_name = project_name.lower()
+
+    # replace special characters with dashes
+    project_name = re.sub('[^a-z0-9-]', '-', project_name)
+
+    # remove repeated and trailing dashes
+    project_name = re.sub('-+', '-', project_name).strip('-')
+    return project_name


### PR DESCRIPTION
This commit moves `get_unique_project_name` to `utils.py` and then use that when generating the name. It also adds a check to the method to validate the project name.