### PR TITLE
Make it easier to run CI locally

### DIFF
--- a/.github/workflows/test-py39-functional-microshift.yaml
+++ b/.github/workflows/test-py39-functional-microshift.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  PYTHONWARNINGS: ignore
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-py39-functional-microshift.yaml
+++ b/.github/workflows/test-py39-functional-microshift.yaml
@@ -9,6 +9,7 @@ on:
 env:
   PYTHONWARNINGS: ignore
   KUBECONFIG: ${{ github.workspace }}/kubeconfig
+  ACCT_MGT_VERSION: "acd4f462104de6cb8af46baecff2ed968612742d"
 
 jobs:
   build:

--- a/.github/workflows/test-py39-functional-microshift.yaml
+++ b/.github/workflows/test-py39-functional-microshift.yaml
@@ -21,6 +21,14 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Upgrade and install packages
+        run: |
+          bash ./ci/setup-ubuntu.sh
+
+      - name: Install oc/kubectl clients
+        run: |
+          bash ./ci/setup-oc-client.sh
+
       - name: Install Microshift
         run: |
           ./ci/microshift.sh

--- a/.github/workflows/test-py39-functional-microshift.yaml
+++ b/.github/workflows/test-py39-functional-microshift.yaml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.9"
 
       - name: Upgrade and install packages
         run: |

--- a/.github/workflows/test-py39-functional-microshift.yaml
+++ b/.github/workflows/test-py39-functional-microshift.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   PYTHONWARNINGS: ignore
+  KUBECONFIG: ${{ github.workspace }}/kubeconfig
 
 jobs:
   build:

--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -13,16 +13,21 @@ mkdir -p "$test_dir"
 
 echo '127.0.0.1  onboarding-onboarding.cluster.local' | sudo tee -a /etc/hosts
 
+echo "::group::Start microshift container"
 sudo docker run -d --rm --name microshift --privileged \
     --network host \
     -v microshift-data:/var/lib \
     quay.io/microshift/microshift-aio:latest
+echo "::endgroup::"
 
+echo "::group::Start registry container"
 sudo docker run -d --name registry --network host registry:2
+echo "::endgroup::"
 
 KUBECONFIG_FULL_PATH="$(readlink -f "$KUBECONFIG")"
 mkdir -p "${KUBECONFIG_FULL_PATH%/*}"
 
+echo "::group::Wait for Microshift"
 for try in {0..10}; do
 	echo "copying kubeconfig {$try}"
 	sudo docker cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig \
@@ -31,17 +36,23 @@ for try in {0..10}; do
 done
 
 while ! oc get route -A; do
-    echo "Waiting on Microshift"
+    echo "Waiting for Microshift"
     sleep 5
 done
+echo "::endgroup::"
 
 # Install OpenShift Account Management
 git clone "${ACCT_MGT_REPOSITORY}" "$test_dir/openshift-acct-mgt"
 git -C "$test_dir/openshift-acct-mgt" checkout "$ACCT_MGT_VERSION"
+
+echo "::group::Build openshift-acct-mgt image"
 sudo docker build "$test_dir/openshift-acct-mgt" -t "localhost:5000/cci-moc/openshift-acct-mgt:latest"
 sudo docker push "localhost:5000/cci-moc/openshift-acct-mgt:latest"
+echo "::endgroup::"
 
+echo "::group::Deploy openshift-acct-mgt"
 oc apply -k "$test_dir/openshift-acct-mgt/k8s/overlays/crc"
 oc wait -n onboarding --for=condition=available --timeout=800s deployment/onboarding
+echo "::endgroup::"
 
 sleep 60

--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -3,6 +3,8 @@
 #
 set -xe
 
+: "${KUBECONFIG:=$HOME/.kube/config}"
+
 export ACCT_MGT_VERSION="acd4f462104de6cb8af46baecff2ed968612742d"
 
 echo '127.0.0.1  onboarding-onboarding.cluster.local' | sudo tee -a /etc/hosts
@@ -17,8 +19,9 @@ sudo docker run -d --name registry --network host registry:2
 # https://github.com/nerc-project/coldfront-plugin-cloud/issues/50
 sleep 30
 
-mkdir ~/.kube
-sudo docker cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig ~/.kube/config
+KUBECONFIG_FULL_PATH="$(readlink -f "$KUBECONFIG")"
+mkdir -p "${KUBECONFIG_FULL_PATH%/*}"
+sudo docker cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig "$KUBECONFIG"
 
 while ! oc get all -h; do
     echo "Waiting on Microshift"

--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -5,12 +5,6 @@ set -xe
 
 export ACCT_MGT_VERSION="acd4f462104de6cb8af46baecff2ed968612742d"
 
-sudo apt-get update && sudo apt-get upgrade -y
-
-if [[ ! "${CI}" == "true" ]]; then
-    sudo apt-get install docker.io docker-compose python3-virtualenv -y
-fi
-
 echo '127.0.0.1  onboarding-onboarding.cluster.local' | sudo tee -a /etc/hosts
 
 sudo docker run -d --rm --name microshift --privileged \
@@ -22,9 +16,6 @@ sudo docker run -d --name registry --network host registry:2
 
 # https://github.com/nerc-project/coldfront-plugin-cloud/issues/50
 sleep 30
-
-curl -O "https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz"
-sudo tar -xf openshift-client-linux.tar.gz -C /usr/local/bin oc kubectl
 
 mkdir ~/.kube
 sudo docker cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig ~/.kube/config

--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -7,6 +7,10 @@ set -xe
 : "${ACCT_MGT_REPOSITORY:="https://github.com/cci-moc/openshift-acct-mgt.git"}"
 : "${KUBECONFIG:=$HOME/.kube/config}"
 
+test_dir="$PWD/testdata"
+rm -rf "$test_dir"
+mkdir -p "$test_dir"
+
 echo '127.0.0.1  onboarding-onboarding.cluster.local' | sudo tee -a /etc/hosts
 
 sudo docker run -d --rm --name microshift --privileged \
@@ -32,13 +36,12 @@ while ! oc get route -A; do
 done
 
 # Install OpenShift Account Management
-git clone "${ACCT_MGT_REPOSITORY}" ~/openshift-acct-mgt
-cd ~/openshift-acct-mgt
-git checkout "$ACCT_MGT_VERSION"
-sudo docker build . -t "localhost:5000/cci-moc/openshift-acct-mgt:latest"
+git clone "${ACCT_MGT_REPOSITORY}" "$test_dir/openshift-acct-mgt"
+git -C "$test_dir/openshift-acct-mgt" checkout "$ACCT_MGT_VERSION"
+sudo docker build "$test_dir/openshift-acct-mgt" -t "localhost:5000/cci-moc/openshift-acct-mgt:latest"
 sudo docker push "localhost:5000/cci-moc/openshift-acct-mgt:latest"
 
-oc apply -k k8s/overlays/crc
+oc apply -k "$test_dir/openshift-acct-mgt/k8s/overlays/crc"
 oc wait -n onboarding --for=condition=available --timeout=800s deployment/onboarding
 
 sleep 60

--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -3,9 +3,9 @@
 #
 set -xe
 
+: "${ACCT_MGT_VERSION:="master"}"
+: "${ACCT_MGT_REPOSITORY:="https://github.com/cci-moc/openshift-acct-mgt.git"}"
 : "${KUBECONFIG:=$HOME/.kube/config}"
-
-export ACCT_MGT_VERSION="acd4f462104de6cb8af46baecff2ed968612742d"
 
 echo '127.0.0.1  onboarding-onboarding.cluster.local' | sudo tee -a /etc/hosts
 
@@ -29,7 +29,7 @@ while ! oc get all -h; do
 done
 
 # Install OpenShift Account Management
-git clone https://github.com/cci-moc/openshift-acct-mgt.git ~/openshift-acct-mgt
+git clone "${ACCT_MGT_REPOSITORY}" ~/openshift-acct-mgt
 cd ~/openshift-acct-mgt
 git checkout "$ACCT_MGT_VERSION"
 sudo docker build . -t "localhost:5000/cci-moc/openshift-acct-mgt:latest"

--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -16,14 +16,17 @@ sudo docker run -d --rm --name microshift --privileged \
 
 sudo docker run -d --name registry --network host registry:2
 
-# https://github.com/nerc-project/coldfront-plugin-cloud/issues/50
-sleep 30
-
 KUBECONFIG_FULL_PATH="$(readlink -f "$KUBECONFIG")"
 mkdir -p "${KUBECONFIG_FULL_PATH%/*}"
-sudo docker cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig "$KUBECONFIG"
 
-while ! oc get all -h; do
+for try in {0..10}; do
+	echo "copying kubeconfig {$try}"
+	sudo docker cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig \
+		"${KUBECONFIG}" && break
+	sleep 2
+done
+
+while ! oc get route -A; do
     echo "Waiting on Microshift"
     sleep 5
 done

--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -43,6 +43,7 @@ echo "::endgroup::"
 
 # Install OpenShift Account Management
 git clone "${ACCT_MGT_REPOSITORY}" "$test_dir/openshift-acct-mgt"
+git -C "$test_dir/openshift-acct-mgt" config advice.detachedHead false
 git -C "$test_dir/openshift-acct-mgt" checkout "$ACCT_MGT_VERSION"
 
 echo "::group::Build openshift-acct-mgt image"

--- a/ci/setup-oc-client.sh
+++ b/ci/setup-oc-client.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -xe
+
+curl -sf "https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz" |
+	sudo tar -xzf - -C /usr/local/bin oc kubectl

--- a/ci/setup-ubuntu.sh
+++ b/ci/setup-ubuntu.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -xe
+
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install -y python3-virtualenv


### PR DESCRIPTION
This is a series of changes to make it easier to run the CI tests in a local Linux environment. In particular:

- We move more configuration into environment variables
- We move distribution-specific package installs to a separate script
- We avoid conflicts with host services running on the same ports used by Microshift and the image registry
- We make it possible to run the tests without clobbering a local `~/.kube/config` file