### PR TITLE
Initial REST API to list Allocations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-coldfront >= 1.0.4
+git+https://github.com/knikolla/coldfront@coldfront_plugin_cloud_urls#egg=coldfront
+djangorestframework
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient
 python-memcached==1.59

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 git+https://github.com/knikolla/coldfront@coldfront_plugin_cloud_urls#egg=coldfront
+mozilla-django-oidc
 djangorestframework
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,8 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    coldfront >= 1.0.4
+    coldfront @ git+https://github.com/knikolla/coldfront@coldfront_plugin_cloud_urls#egg=coldfront
+    djangorestframework
     python-cinderclient
     python-keystoneclient
     python-memcached == 1.59

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ python_requires = >=3.8
 install_requires =
     coldfront @ git+https://github.com/knikolla/coldfront@coldfront_plugin_cloud_urls#egg=coldfront
     djangorestframework
+    mozilla-django-oidc
     python-cinderclient
     python-keystoneclient
     python-memcached == 1.59

--- a/src/coldfront_plugin_cloud/api/serializers.py
+++ b/src/coldfront_plugin_cloud/api/serializers.py
@@ -1,0 +1,65 @@
+from rest_framework import serializers
+
+from coldfront.core.allocation.models import Allocation
+from coldfront.core.allocation.models import Project
+
+from coldfront_plugin_cloud import attributes
+
+
+class ProjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Project
+        fields = [
+            'id',
+            'title',
+            'pi',
+            'description',
+            'field_of_science',
+            'status'
+        ]
+
+    pi = serializers.SerializerMethodField()
+    field_of_science = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+
+    def get_pi(self, obj: Project) -> str:
+        return obj.pi.username
+
+    def get_field_of_science(self, obj: Project) -> str:
+        return obj.field_of_science.description
+
+    def get_status(self, obj: Project) -> str:
+        return obj.status.name
+
+
+class AllocationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Allocation
+        fields = [
+            'id',
+            'project',
+            'description',
+            'resource',
+            'status',
+            'attributes'
+        ]
+
+    resource = serializers.SerializerMethodField()
+    project = ProjectSerializer()
+    attributes = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+
+    def get_resource(self, obj: Allocation) -> dict:
+        resource = obj.resources.first()
+        return {
+            'name': resource.name,
+            'resource_type': resource.resource_type.name
+        }
+
+    def get_attributes(self, obj: Allocation):
+        return {
+            attr: obj.get_attribute(attr) for attr in attributes.ALLOCATION_ATTRIBUTES
+        }
+
+    def get_status(self, obj: Allocation) -> str:
+        return obj.status.name

--- a/src/coldfront_plugin_cloud/config.py
+++ b/src/coldfront_plugin_cloud/config.py
@@ -3,7 +3,6 @@ from coldfront.config.env import ENV
 
 for app in [
     'rest_framework',
-    'rest_framework.authtoken',
     'coldfront_plugin_cloud',
 ]:
     if app not in INSTALLED_APPS:

--- a/src/coldfront_plugin_cloud/config.py
+++ b/src/coldfront_plugin_cloud/config.py
@@ -1,7 +1,10 @@
 from coldfront.config.base import INSTALLED_APPS
 from coldfront.config.env import ENV
 
-if 'coldfront_plugin_cloud' not in INSTALLED_APPS:
-    INSTALLED_APPS += [
-        'coldfront_plugin_cloud',
-    ]
+for app in [
+    'rest_framework',
+    'rest_framework.authtoken',
+    'coldfront_plugin_cloud',
+]:
+    if app not in INSTALLED_APPS:
+        INSTALLED_APPS.append(app)

--- a/src/coldfront_plugin_cloud/tests/base.py
+++ b/src/coldfront_plugin_cloud/tests/base.py
@@ -30,7 +30,7 @@ class TestBase(TestCase):
     def setUp(self) -> None:
         # Otherwise output goes to the terminal for every test that is run
         backup, sys.stdout = sys.stdout, open(devnull, 'a')
-        call_command('initial_setup', )
+        call_command('initial_setup', '-f')
         call_command('load_test_data')
         call_command('register_cloud_attributes')
         sys.stdout = backup

--- a/src/coldfront_plugin_cloud/tests/base.py
+++ b/src/coldfront_plugin_cloud/tests/base.py
@@ -35,6 +35,8 @@ class TestBase(TestCase):
         call_command('register_cloud_attributes')
         sys.stdout = backup
 
+        self.admin_user = User.objects.get(username='admin')
+
     @staticmethod
     def new_user(username=None) -> User:
         username = username or f'{uuid.uuid4().hex}@example.com'

--- a/src/coldfront_plugin_cloud/tests/unit/test_api_allocations.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_api_allocations.py
@@ -1,0 +1,67 @@
+import json
+import uuid
+
+from coldfront_plugin_cloud import attributes, utils
+from coldfront_plugin_cloud.tests import base
+
+from rest_framework.test import APIClient
+
+
+class TestApiAllocations(base.TestBase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resource = self.new_resource(name='Devstack',
+                                          auth_url='http://example.com')
+
+    def test_api(self):
+        client = APIClient()
+
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 1)
+
+        allocated_project_id = uuid.uuid4().hex
+        allocated_project_name = uuid.uuid4().hex
+        utils.set_attribute_on_allocation(
+            allocation, attributes.ALLOCATION_PROJECT_ID, allocated_project_id
+        )
+        utils.set_attribute_on_allocation(
+            allocation, attributes.ALLOCATION_PROJECT_NAME, allocated_project_name
+        )
+
+        allocation.refresh_from_db()
+
+        http_response = client.get('/cloud-api/allocations/')
+        self.assertEqual(http_response.status_code, 200)
+        self.assertGreaterEqual(len(json.loads(http_response.content)), 1)
+
+        http_response = self.client.get(f'/cloud-api/allocations/{allocation.pk}/')
+        self.assertEqual(http_response.status_code, 200)
+        r = json.loads(http_response.content)
+
+        self.assertEqual(
+            r['project'],
+            {
+                'id': allocation.project.pk,
+                'title': allocation.project.title,
+                'description': allocation.project.description,
+                'pi': allocation.project.pi.username,
+                'field_of_science': allocation.project.field_of_science.description,
+                'status': allocation.project.status.name
+            }
+        )
+        self.assertEqual(r['description'], allocation.description)
+        self.assertEqual(
+            r['resource'],
+            {'name': 'Devstack', 'resource_type': 'OpenStack'}
+        )
+        self.assertEqual(r['status'], 'Active')
+        self.assertEqual(
+            r['attributes'],
+            {
+                attributes.ALLOCATION_PROJECT_ID: allocated_project_id,
+                attributes.ALLOCATION_PROJECT_NAME: allocated_project_name
+            }
+        )
+        self.assertEqual(len(r['attributes'].keys()), 2)

--- a/src/coldfront_plugin_cloud/tests/unit/test_attribute_migration.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_attribute_migration.py
@@ -16,7 +16,7 @@ class TestAttributeMigration(base.TestBase):
     def setUp(self) -> None:
         # Run initial setup but do not register the attributes
         backup, sys.stdout = sys.stdout, open(devnull, 'a')
-        call_command('initial_setup', )
+        call_command('initial_setup', '-f')
         call_command('load_test_data')
         sys.stdout = backup
 

--- a/src/coldfront_plugin_cloud/urls.py
+++ b/src/coldfront_plugin_cloud/urls.py
@@ -1,13 +1,25 @@
+import os
+
 from rest_framework import routers, viewsets
+from rest_framework.authentication import SessionAuthentication, BasicAuthentication
+from rest_framework.permissions import IsAdminUser
+from mozilla_django_oidc.contrib.drf import OIDCAuthentication
 
 from coldfront.core.allocation.models import Allocation
 
 from coldfront_plugin_cloud.api import serializers
 
+if os.getenv('PLUGIN_OIDC') == 'True':
+    AUTHENTICATION_CLASSES = [OIDCAuthentication]
+else:
+    AUTHENTICATION_CLASSES = [SessionAuthentication, BasicAuthentication]
+
 
 class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Allocation.objects.filter(status__name='Active')
     serializer_class = serializers.AllocationSerializer
+    authentication_classes = AUTHENTICATION_CLASSES
+    permission_classes = [IsAdminUser]
 
 
 router = routers.SimpleRouter()

--- a/src/coldfront_plugin_cloud/urls.py
+++ b/src/coldfront_plugin_cloud/urls.py
@@ -1,0 +1,16 @@
+from rest_framework import routers, viewsets
+
+from coldfront.core.allocation.models import Allocation
+
+from coldfront_plugin_cloud.api import serializers
+
+
+class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Allocation.objects.filter(status__name='Active')
+    serializer_class = serializers.AllocationSerializer
+
+
+router = routers.SimpleRouter()
+router.register(r'allocations', AllocationViewSet)
+
+urlpatterns = router.urls

--- a/src/local_settings.py
+++ b/src/local_settings.py
@@ -1,3 +1,4 @@
+import os
 import pkgutil
 
 from coldfront.config.settings import *
@@ -6,3 +7,16 @@ from django.conf import settings
 plugin_openstack = pkgutil.get_loader('coldfront_plugin_cloud.config')
 
 include(plugin_openstack.get_filename())
+
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ],
+}
+
+if os.getenv('PLUGIN_OIDC') == 'True':
+    REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'].append(
+        'mozilla_django_oidc.contrib.drf.OIDCAuthentication',
+    )


### PR DESCRIPTION
This is roughly based on https://github.com/ubccr/coldfront/pull/425
and creates a simple API for listing active resource allocations at
/cloud-api/allocations and /cloud-api/allocations/<id>.

---

The first commit introduces the API using djangorestframework, and required switching to a
fork of ColdFront to allow extending the routes to include the routes introduced by the plugin.
https://github.com/knikolla/coldfront/commit/edf99cf3104ee96ad7d3d27dabb0b297921344ea

---

The second commit limits the Allocations REST API to admin users.

In the presence of the PLUGIN_OIDC flag, which signals that ColdFront
has been configured with OpenID Connect, this only allows
authentication via access tokens.

If the flag has not been detected, than it falls back to
Basic and Session authentications.

---

One thing of note, is that this is based on the current state of master and one of the changes there is [introducing a confirmation dialog](https://github.com/ubccr/coldfront/pull/460/files) to `coldfront initial_setup`, so I've had to update some of the testing code to take that into account. This will have no consequences on `coldfront-nerc` as we're not planning on running `initial_setup` or scripting it's execution there.

Closes #89 