### PR TITLE
Remove old microshift volume

### DIFF
--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -12,6 +12,7 @@ rm -rf "$test_dir"
 mkdir -p "$test_dir"
 
 sudo docker rm -f microshift registry
+sudo docker volume rm -f microshift-data
 
 registry_port=$(( RANDOM % 1000 + 10000 ))
 


### PR DESCRIPTION
The stale data can cause issues when starting microshift.