### PR TITLE
Update devstack.sh to use 2023.1 release

### DIFF
--- a/ci/devstack.sh
+++ b/ci/devstack.sh
@@ -21,8 +21,8 @@ cd /opt/stack/devstack-plugin-oidc/tools && sudo docker-compose up -d
 
 # Install and start Devstack
 git clone https://github.com/openstack/devstack.git /opt/stack/devstack
-git checkout "stable/2023.1"
 cd /opt/stack/devstack
+git checkout "stable/2023.1"
 
 cp samples/local.conf .
 

--- a/ci/devstack.sh
+++ b/ci/devstack.sh
@@ -21,6 +21,7 @@ cd /opt/stack/devstack-plugin-oidc/tools && sudo docker-compose up -d
 
 # Install and start Devstack
 git clone https://github.com/openstack/devstack.git /opt/stack/devstack
+git checkout "stable/2023.1"
 cd /opt/stack/devstack
 
 cp samples/local.conf .


### PR DESCRIPTION
Instead of master, this may be more stable going forward.