### PR TITLE
Add missing apt-get update to radosgw setup script

### DIFF
--- a/ci/radosgw.sh
+++ b/ci/radosgw.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
-set -x
+
+set -ex
 
 OSD_BIN_DIR=/tmp
 
 
 function install_pkgs() {
+  apt-get update
   apt-get install -y cephadm lvm2 ipcalc jq iproute2
 }
 


### PR DESCRIPTION
The ci/radowsgw.sh script was attempting to run `apt-get install` without
first running `apt-get update`, which means that it can fail if the apt
cache is out-of-date [1].

This commit ensures that we call `apt-get update` to update the package
cache before attempting to install packages.

[1]: https://github.com/nerc-project/coldfront-plugin-cloud/actions/runs/4948674599/jobs/8850412133#step:5:24
