### PR TITLE
Implements the command to generate storage invoices

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -74,6 +74,7 @@ class Command(BaseCommand):
             if billed > 0:
                 row = InvoiceRow(
                     Interval=f"{options['start']} - {options['end']}",
+                    Project_Name=allocation.get_attribute(attributes.ALLOCATION_PROJECT_NAME),
                     Project_ID=allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID),
                     PI=allocation.project.pi,
                     Invoice_Type_Hours=billed,

--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
                     Invoice_Type_Hours=billed,
                     Invoice_Type=attr,
                 )
-                csv_invoice_writer.write(
+                csv_invoice_writer.writerow(
                     row.get_values()
                 )
 

--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -1,18 +1,52 @@
 import csv
+import dataclasses
 from datetime import datetime
 import logging
-import sys
 
 from coldfront_plugin_cloud import attributes
 from coldfront_plugin_cloud import utils
 
-from novaclient import client as novaclient
 from django.core.management.base import BaseCommand
 from coldfront.core.resource.models import Resource, ResourceType
 from coldfront.core.allocation.models import Allocation, AllocationStatusChoice
 import pytz
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class InvoiceRow:
+    Interval: str = ""
+    Project_Name: str = ""
+    Project_ID: str = ""
+    PI: str = ""
+    Invoice_Email: str = ""
+    Invoice_Address : str = ""
+    Institution: str = ""
+    Institution_Specific_Code: str = ""
+    Invoice_Type_Hours: int = ""
+    Invoice_Type: str = ""
+    Rate: str = ""
+    Cost: str = ""
+
+    @classmethod
+    def get_headers(cls):
+        """Returns all fields for display, with space instead of underscore."""
+        return [
+            field.name.replace("_", " ") for field in dataclasses.fields(cls)
+        ]
+
+    def get_value(self, field: str):
+        """Returns value for a field.
+
+        :param field: Field to return, with or without underscore.
+        """
+        return getattr(self, field.replace(" ", "_"))
+
+    def get_values(self):
+        return [
+            self.get_value(field) for field in self.get_headers()
+        ]
 
 
 def datetime_type(v):
@@ -29,6 +63,24 @@ class Command(BaseCommand):
                             help='End period for billing.')
 
     def handle(self, *args, **options):
+        def process_invoice_row(allocation, attribute, price):
+            """Calculate the value and write the bill using the writer."""
+            time = utils.calculate_quota_unit_hours(
+                allocation, attribute, options['start'], options['end']
+            )
+            billed = time * price
+            if billed > 0:
+                row = InvoiceRow(
+                    Interval=f"{options['start']} - {options['end']}",
+                    Project_ID=allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID),
+                    PI=allocation.project.pi,
+                    Invoice_Type_Hours=billed,
+                    Invoice_Type=attr,
+                )
+                csv_invoice_writer.write(
+                    row.get_values()
+                )
+
         openstack_resources = Resource.objects.filter(
             resource_type=ResourceType.objects.get(
                 name='OpenStack'
@@ -51,53 +103,18 @@ class Command(BaseCommand):
                 f, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL
             )
             # Write Headers
-            csv_invoice_writer.writerow(
-                [
-                    "Interval",
-                    "Project Name",
-                    "Project ID",
-                    "PI",
-                    "Invoice Email",
-                    "Invoice Address",
-                    "Institution",
-                    "Institution Specific Code",
-                    "Invoice Type Hours",
-                    "Invoice Type",
-                    "Rate",
-                    "Cost",
-                ]
-            )
+            csv_invoice_writer.writerow(InvoiceRow.get_headers())
 
             for allocation in openstack_allocations:
                 allocation_str = f'{allocation.pk} of project "{allocation.project.title}"'
                 msg = f'Starting billing for for allocation {allocation_str}.'
                 logger.debug(msg)
 
-                for attr, price_per_unit in [
+                for attr, price in [
                     (attributes.QUOTA_VOLUMES_GB, 1),
                     (attributes.QUOTA_OBJECT_GB, 1)
                 ]:
-                    time = utils.calculate_quota_unit_hours(
-                        allocation, attr, options['start'], options['end']
-                    )
-                    billed = time * price_per_unit
-                    if billed > 0:
-                        csv_invoice_writer.writerow(
-                            [
-                                f"{options['start']} - {options['end']}",
-                                allocation.get_attribute(attributes.ALLOCATION_PROJECT_NAME),
-                                allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID),
-                                allocation.project.pi,
-                                "",  # Invoice Email
-                                "",  # Invoice Address
-                                "",  # Institutions
-                                "",  # Institution Specific Code
-                                billed,
-                                attr,
-                                "",  # Rate
-                                "",  # Cost
-                            ]
-                        )
+                    process_invoice_row(allocation, attr, price)
 
             for allocation in openshift_allocations:
                 allocation_str = f'{allocation.pk} of project "{allocation.project.title}"'
@@ -107,24 +124,4 @@ class Command(BaseCommand):
                 for attr, price_per_unit in [
                     (attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 1)
                 ]:
-                    time = utils.calculate_quota_unit_hours(
-                        allocation, attr, options['start'], options['end']
-                    )
-                    billed = time * price_per_unit
-                    if billed > 0:
-                        csv_invoice_writer.writerow(
-                            [
-                                f"{options['start']} - {options['end']}",
-                                allocation.get_attribute(attributes.ALLOCATION_PROJECT_NAME),
-                                allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID),
-                                allocation.project.pi,
-                                "",  # Invoice Email
-                                "",  # Invoice Address
-                                "",  # Institutions
-                                "",  # Institution Specific Code
-                                billed,
-                                attr,
-                                "",  # Rate
-                                "",  # Cost
-                            ]
-                        )
+                    process_invoice_row(allocation, attr, price)

--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -1,0 +1,125 @@
+import csv
+from datetime import datetime
+import logging
+import sys
+
+from coldfront_plugin_cloud import attributes
+from coldfront_plugin_cloud import utils
+
+from novaclient import client as novaclient
+from django.core.management.base import BaseCommand
+from coldfront.core.resource.models import Resource, ResourceType
+from coldfront.core.allocation.models import Allocation, AllocationStatusChoice
+import pytz
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Generate invoices for storage billing."
+
+    def add_arguments(self, parser):
+        parser.add_argument('--start', type=str, required=True,
+                            help='Start period for billing.')
+        parser.add_argument('--end', type=str, required=True,
+                            help='End period for billing.')
+
+    def handle(self, *args, **options):
+        start = pytz.utc.localize(datetime.strptime(options["start"], '%Y-%m-%d'))
+        end = pytz.utc.localize(datetime.strptime(options["end"], '%Y-%m-%d'))
+
+        openstack_resources = Resource.objects.filter(
+            resource_type=ResourceType.objects.get(
+                name='OpenStack'
+            )
+        )
+        openstack_allocations = Allocation.objects.filter(
+            resources__in=openstack_resources
+        )
+        openshift_resources = Resource.objects.filter(
+            resource_type=ResourceType.objects.get(
+                name='OpenShift'
+            )
+        )
+        openshift_allocations = Allocation.objects.filter(
+            resources__in=openshift_resources
+        )
+
+        with open('invoices.csv', 'w', newline='') as f:
+            csv_invoice_writer = csv.writer(
+                f, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL
+            )
+            # Write Headers
+            csv_invoice_writer.writerow(
+                [
+                    "Interval",
+                    "Project Name",
+                    "Project ID",
+                    "PI",
+                    "Invoice Email",
+                    "Invoice Address",
+                    "Institution",
+                    "Institution Specific Code",
+                    "Invoice Type Hours",
+                    "Invoice Type",
+                    "Rate",
+                    "Cost",
+                ]
+            )
+
+            for allocation in openstack_allocations:
+                allocation_str = f'{allocation.pk} of project "{allocation.project.title}"'
+                msg = f'Starting billing for for allocation {allocation_str}.'
+                logger.debug(msg)
+
+                for attr, price_per_unit in [
+                    (attributes.QUOTA_VOLUMES_GB, 1),
+                    (attributes.QUOTA_OBJECT_GB, 1)
+                ]:
+                    time = utils.calculate_quota_unit_hours(allocation, attr, start, end)
+                    billed = time * price_per_unit
+                    if billed > 0:
+                        csv_invoice_writer.writerow(
+                            [
+                                f"{options['start']} - {options['end']}",
+                                allocation.get_attribute(attributes.ALLOCATION_PROJECT_NAME),
+                                allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID),
+                                allocation.project.pi,
+                                "",  # Invoice Email
+                                "",  # Invoice Address
+                                "",  # Institutions
+                                "",  # Institution Specific Code
+                                billed,
+                                attr,
+                                "",  # Rate
+                                "",  # Cost
+                            ]
+                        )
+
+            for allocation in openshift_allocations:
+                allocation_str = f'{allocation.pk} of project "{allocation.project.title}"'
+                msg = f'Starting billing for for allocation {allocation_str}.'
+                logger.debug(msg)
+
+                for attr, price_per_unit in [
+                    (attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 1)
+                ]:
+                    time = utils.calculate_quota_unit_hours(allocation, attr, start, end)
+                    billed = time * price_per_unit
+                    if billed > 0:
+                        csv_invoice_writer.writerow(
+                            [
+                                f"{options['start']} - {options['end']}",
+                                allocation.get_attribute(attributes.ALLOCATION_PROJECT_NAME),
+                                allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID),
+                                allocation.project.pi,
+                                "",  # Invoice Email
+                                "",  # Invoice Address
+                                "",  # Institutions
+                                "",  # Institution Specific Code
+                                billed,
+                                attr,
+                                "",  # Rate
+                                "",  # Cost
+                            ]
+                        )

--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -61,6 +61,8 @@ class Command(BaseCommand):
                             help='Start period for billing.')
         parser.add_argument('--end', type=datetime_type, required=True,
                             help='End period for billing.')
+        parser.add_argument('--output', type=str, default='invoices.csv',
+                             help='CSV file to write invoices to.')
 
     def handle(self, *args, **options):
         def process_invoice_row(allocation, attribute, price):
@@ -98,7 +100,7 @@ class Command(BaseCommand):
             resources__in=openshift_resources
         )
 
-        with open('invoices.csv', 'w', newline='') as f:
+        with open(options['output'], 'w', newline='') as f:
             csv_invoice_writer = csv.writer(
                 f, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL
             )

--- a/src/coldfront_plugin_cloud/tests/base.py
+++ b/src/coldfront_plugin_cloud/tests/base.py
@@ -87,7 +87,7 @@ class TestBase(TestCase):
         )
         return pu
 
-    def new_allocation(self, project, resource, quantity):
+    def new_allocation(self, project, resource, quantity) -> Allocation:
         allocation, _ = Allocation.objects.get_or_create(
             project=project,
             justification='a justification for testing data',

--- a/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
@@ -1,0 +1,229 @@
+import datetime
+import pytz
+
+import freezegun
+
+from coldfront_plugin_cloud import attributes
+from coldfront_plugin_cloud.tests import base
+from coldfront_plugin_cloud import utils
+
+from coldfront.core.allocation import models as allocation_models
+
+
+class TestCalculateAllocationQuotaHours(base.TestBase):
+    def test_new_allocation_quota(self):
+        self.resource = self.new_openshift_resource(
+            name="",
+            auth_url="",
+        )
+
+        with freezegun.freeze_time("2020-03-15 00:01:00"):
+            user = self.new_user()
+            project = self.new_project(pi=user)
+            allocation = self.new_allocation(project, self.resource, 2)
+            utils.set_attribute_on_allocation(
+                allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 2)
+
+        with freezegun.freeze_time("2020-03-16 23:59:00"):
+            utils.set_attribute_on_allocation(
+                allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 0)
+
+        allocation.refresh_from_db()
+
+        value = utils.calculate_quota_unit_hours(
+            allocation,
+            attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
+            pytz.utc.localize(datetime.datetime(2020, 3, 1, 0, 0, 1)),
+            pytz.utc.localize(datetime.datetime(2020, 3, 31, 23, 59, 59))
+        )
+        self.assertEqual(value, 96)
+
+
+    def test_new_allocation_quota_expired(self):
+        """Test that expiration doesn't affect invoicing."""
+        self.resource = self.new_openshift_resource(
+            name="",
+            auth_url="",
+        )
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 2)
+        allocation.status = allocation_models.AllocationStatusChoice.objects.get(name="Active")
+
+        with freezegun.freeze_time("2020-03-15 00:01:00"):
+            utils.set_attribute_on_allocation(
+                allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 2)
+
+        with freezegun.freeze_time("2020-03-16 23:59:00"):
+            allocation.status = allocation_models.AllocationStatusChoice.objects.get(name="Expired")
+            allocation.save()
+
+        allocation.refresh_from_db()
+
+        value = utils.calculate_quota_unit_hours(
+            allocation,
+            attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
+            pytz.utc.localize(datetime.datetime(2020, 3, 1, 0, 0, 1)),
+            pytz.utc.localize(datetime.datetime(2020, 3, 31, 23, 59, 59))
+        )
+        self.assertEqual(value, 816)
+
+    def test_new_allocation_quota_denied(self):
+        """Test a simple case of invoicing until a status change."""
+        self.resource = self.new_openshift_resource(
+            name="",
+            auth_url="",
+        )
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 2)
+
+        with freezegun.freeze_time("2020-03-15 00:01:00"):
+            utils.set_attribute_on_allocation(
+                allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 2)
+
+        with freezegun.freeze_time("2020-03-16 23:59:00"):
+            allocation.status = allocation_models.AllocationStatusChoice.objects.get(name="Denied")
+            allocation.save()
+
+        allocation.refresh_from_db()
+
+        value = utils.calculate_quota_unit_hours(
+            allocation,
+            attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
+            pytz.utc.localize(datetime.datetime(2020, 3, 1, 0, 0, 1)),
+            pytz.utc.localize(datetime.datetime(2020, 3, 31, 23, 59, 59))
+        )
+        self.assertEqual(value, 96)
+
+    def test_new_allocation_quota_last_revoked(self):
+        """Test that we correctly distinguish the last transition to an unbilled state."""
+        self.resource = self.new_openshift_resource(
+            name="",
+            auth_url="",
+        )
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 2)
+
+        # Billable
+        with freezegun.freeze_time("2020-03-15 00:01:00"):
+            allocation.status = allocation_models.AllocationStatusChoice.objects.get(name="New")
+            utils.set_attribute_on_allocation(
+                allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 2)
+            allocation.save()
+
+        allocation.refresh_from_db()
+
+        with freezegun.freeze_time("2020-03-16 23:59:00"):
+            allocation.status = allocation_models.AllocationStatusChoice.objects.get(name="Denied")
+            allocation.save()
+
+        allocation.refresh_from_db()
+
+        # Billable until here, since this is the last transition into an unbillable status.
+        with freezegun.freeze_time("2020-03-17 23:59:00"):
+            allocation.status = allocation_models.AllocationStatusChoice.objects.get(name="Revoked")
+            allocation.save()
+
+        allocation.refresh_from_db()
+
+        value = utils.calculate_quota_unit_hours(
+            allocation,
+            attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
+            pytz.utc.localize(datetime.datetime(2020, 3, 1, 0, 0, 1)),
+            pytz.utc.localize(datetime.datetime(2020, 3, 31, 23, 59, 59))
+        )
+        self.assertEqual(value, 144)
+
+    def test_new_allocation_quota_new(self):
+        self.resource = self.new_openshift_resource(
+            name="",
+            auth_url="",
+        )
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 2)
+
+        allocation.refresh_from_db()
+
+        value = utils.calculate_quota_unit_hours(
+            allocation,
+            attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
+            pytz.utc.localize(datetime.datetime(2020, 4, 1, 0, 0, 0)),
+            pytz.utc.localize(datetime.datetime(2020, 5, 1, 0, 0, 0))
+        )
+        self.assertEqual(value, 0)
+
+    def test_new_allocation_quota_never_approved(self):
+        self.resource = self.new_openshift_resource(
+            name="",
+            auth_url="",
+        )
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 2)
+
+        # We don't set any attributes. This simulates a resource
+        # allocation never being approved.
+
+        allocation.refresh_from_db()
+
+        value = utils.calculate_quota_unit_hours(
+            allocation,
+            attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
+            pytz.utc.localize(datetime.datetime(2020, 3, 1, 0, 0, 1)),
+            pytz.utc.localize(datetime.datetime(2020, 3, 31, 23, 59, 59))
+        )
+        self.assertEqual(value, 0)
+
+    def test_new_allocation_quota_change_request(self):
+        self.resource = self.new_openshift_resource(
+            name="",
+            auth_url="",
+        )
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 2)
+
+        with freezegun.freeze_time("2020-03-15 00:01:00"):
+            utils.set_attribute_on_allocation(
+                allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 2)
+
+        with freezegun.freeze_time("2020-03-16 23:59:00"):
+            cr = allocation_models.AllocationChangeRequest.objects.create(
+                allocation=allocation,
+                status = allocation_models.AllocationChangeStatusChoice.objects.filter(
+                    name="Approved").first()
+            )
+            attr = allocation_models.AllocationAttribute.objects.filter(
+                allocation_attribute_type__name=attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
+                allocation=allocation
+            ).first()
+            allocation_models.AllocationAttributeChangeRequest.objects.create(
+                allocation_change_request=cr,
+                allocation_attribute=attr,
+                new_value=0,
+            )
+
+        with freezegun.freeze_time("2020-03-17 23:59:00"):
+            utils.set_attribute_on_allocation(
+                allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 0)
+
+        with freezegun.freeze_time("2020-03-18 23:59:00"):
+            utils.set_attribute_on_allocation(
+                allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 2)
+
+        with freezegun.freeze_time("2020-03-19 23:59:00"):
+            utils.set_attribute_on_allocation(
+                allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 0)
+
+        allocation.refresh_from_db()
+
+        value = utils.calculate_quota_unit_hours(
+            allocation,
+            attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
+            pytz.utc.localize(datetime.datetime(2020, 3, 1, 0, 0, 1)),
+            pytz.utc.localize(datetime.datetime(2020, 3, 31, 23, 59, 59))
+        )
+        self.assertEqual(value, 144)

--- a/src/coldfront_plugin_cloud/utils.py
+++ b/src/coldfront_plugin_cloud/utils.py
@@ -147,8 +147,7 @@ def calculate_quota_unit_hours(allocation: Allocation,
         last_event_time = event_time
         last_event_value = int(event.value)
 
-    # No special logic is required after processing the last event, just
-    # continue treating the
+    # The value remains the same from the last event until the end.
     since_last_event = math.ceil((end - last_event_time).total_seconds())
     value_times_seconds += since_last_event * last_event_value
 

--- a/src/coldfront_plugin_cloud/utils.py
+++ b/src/coldfront_plugin_cloud/utils.py
@@ -5,7 +5,8 @@ import pytz
 import re
 import secrets
 
-from coldfront.core.allocation.models import (AllocationAttribute,
+from coldfront.core.allocation.models import (Allocation,
+                                              AllocationAttribute,
                                               AllocationAttributeType,
                                               AllocationChangeRequest,
                                               AllocationAttributeChangeRequest,)
@@ -54,15 +55,19 @@ def get_sanitized_project_name(project_name):
     return project_name
 
 
-def calculate_quota_unit_hours(allocation, attribute, start, end):
+def calculate_quota_unit_hours(allocation: Allocation,
+                               attribute: str,
+                               start: datetime,
+                               end: datetime):
     """Returns unit*hours of quota allocated in a given period.
 
     Calculation is rounded up by the hour and tracks the history of change
     requests.
 
+    :param allocation: Allocation object with the attribute to calculate.
     :param attribute: Name of the attribute to calculate.
     :param start: Start time to being calculation.
-    :param end: Optional. End time for calculation.
+    :param end: End time for calculation.
     :return: Value of attribute * amount of hours.
     """
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 git+https://github.com/ubccr/coldfront@2e60db247fd9a9b0d1299f1e98f1e4ef5f5c259b#egg=coldfront
+freezegun
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient
 python-memcached==1.59


### PR DESCRIPTION
This PR implements the management command `coldfront calculate_quota_unit_hours --start <start> --end <end>` that generates the  CSV invoice for the given period.

Some minor polish is still missing but it's operational. 