### PR TITLE
openshift: add rhods ns labels by default

### DIFF
--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -150,9 +150,11 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         headers = {"Content-type": "application/json"}
         annotations = {"cf_project_id": str(self.allocation.project_id),
                        "cf_pi": self.allocation.project.pi.username}
+        labels = {'opendatahub.io/dashboard': True}
 
         payload = {"displayName": project_name,
-                   "annotations": annotations}
+                   "annotations": annotations,
+                   "labels": labels}
         r = self.session.put(url, data=json.dumps(payload), headers=headers)
         self.check_response(r)
 


### PR DESCRIPTION
This implicitly applies the following label to all projects which is required in order for them to show up as available projects/namespace in the RHODS/OpenDataHub dashboard:
```
opendatahub.io/dashboard: "true"
```

**NOTE**: Depends on https://github.com/CCI-MOC/openshift-acct-mgt/pull/98