### PR TITLE
fix recent radosgw CI/CD pipeline failures

### DIFF
--- a/ci/radosgw.sh
+++ b/ci/radosgw.sh
@@ -42,18 +42,19 @@ EOF
     --config /tmp/ceph.conf \
     --cluster-network $NETWORK \
     --mon-ip $IP \
-    --dashboard-password-noupdate \
-    --initial-dashboard-user admin \
-    --initial-dashboard-password ceph \
     --allow-fqdn-hostname \
-    --single-host-defaults
+    --single-host-defaults \
+    --log-to-file \
+    --skip-firewalld \
+    --skip-dashboard \
+    --skip-monitoring-stack
 }
 
 function osd_setup() {
   OSD1_BIN=$OSD_BIN_DIR/osd0.bin
   OSD2_BIN=$OSD_BIN_DIR/osd1.bin
-  dd if=/dev/zero of=$OSD1_BIN bs=512M count=1
-  dd if=/dev/zero of=$OSD2_BIN bs=512M count=1
+  dd if=/dev/zero of=$OSD1_BIN bs=512M count=2
+  dd if=/dev/zero of=$OSD2_BIN bs=512M count=2
   OSD1_DEV=$(losetup -f)
   losetup $OSD1_DEV $OSD1_BIN
   OSD2_DEV=$(losetup -f)
@@ -61,8 +62,8 @@ function osd_setup() {
   pvcreate $OSD1_DEV
   pvcreate $OSD2_DEV
   vgcreate rgw $OSD1_DEV $OSD2_DEV
-  lvcreate -n rgw-ceph-osd0 -L 500M rgw
-  lvcreate -n rgw-ceph-osd1 -L 500M rgw
+  lvcreate -n rgw-ceph-osd0 -L 1000M rgw
+  lvcreate -n rgw-ceph-osd1 -L 1000M rgw
   cephadm shell ceph orch daemon add osd $HOSTNAME:/dev/rgw/rgw-ceph-osd0
   cephadm shell ceph orch daemon add osd $HOSTNAME:/dev/rgw/rgw-ceph-osd1
 }


### PR DESCRIPTION
This fixes an issue with the radosgw portion of the CI/CD pipeline due to an upstream issue/change with ceph-exporter related to the metrics setup on the cluster. This patch simply disables setting up the monitoring stack altogether given that the metrics setup is not used by this pipeline.

This patch also doubles the size of the OSDs given that the most recent version of ceph deployed by cephadm 17.2.6-0ubuntu0.22.04.1 requires more space. This was determined by the appearance of out-of-space errors
in OSD logs on an external test VM.

In addition to these changes, this patch also disables configuring firewalld given that it's not installed and not necessary for the CI/CD pipeline.