### PR TITLE
fix default RHODS label to use strings

### DIFF
--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -151,7 +151,7 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         headers = {"Content-type": "application/json"}
         annotations = {"cf_project_id": str(self.allocation.project_id),
                        "cf_pi": self.allocation.project.pi.username}
-        labels = {'opendatahub.io/dashboard': True}
+        labels = {'opendatahub.io/dashboard': "true"}
 
         payload = {"displayName": project_name,
                    "annotations": annotations,


### PR DESCRIPTION
This was causing the following error when creating new OpenShift projects:

```
coldfront_plugin_cloud.openshift.ApiException: 400: {"msg":"Unexpected
  response from OpenShift API: Project in version \"v1\" cannot be
    handled as a Project: json: cannot unmarshal bool into Go struct
    field ObjectMeta.metadata.labels of type string"}
```

related: #115