### PR TITLE
fix default GPU quota and update tests

### DIFF
--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -85,7 +85,7 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         url = f"{self.auth_url}/projects/{project_id}/quota"
         payload = dict()
         for key, func in QUOTA_KEY_MAPPING.items():
-            if x := self.allocation.get_attribute(key):
+            if (x := self.allocation.get_attribute(key)) is not None:
                 payload.update(func(x))
         r = self.session.put(url, data=json.dumps({'Quota': payload}))
         self.check_response(r)

--- a/src/coldfront_plugin_cloud/tasks.py
+++ b/src/coldfront_plugin_cloud/tasks.py
@@ -33,7 +33,7 @@ UNIT_QUOTA_MULTIPLIERS = {
         attributes.QUOTA_LIMITS_MEMORY: 4096,
         attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB: 5,
         attributes.QUOTA_REQUESTS_STORAGE: 20,
-        attributes.QUOTA_REQUESTS_GPU: 1,
+        attributes.QUOTA_REQUESTS_GPU: 0,
         attributes.QUOTA_PVC: 2
     }
 }

--- a/src/coldfront_plugin_cloud/tests/functional/openshift/test_allocation.py
+++ b/src/coldfront_plugin_cloud/tests/functional/openshift/test_allocation.py
@@ -120,6 +120,7 @@ class TestAllocation(base.TestBase):
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_MEMORY), 2 * 4096)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB), 2 * 5)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_STORAGE), 2 * 20)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_GPU), 2 * 0)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_PVC), 2 * 2)
 
         quota = allocator.get_quota(project_id)['Quota']
@@ -131,6 +132,7 @@ class TestAllocation(base.TestBase):
             ":limits.memory": "8Gi",
             ":limits.ephemeral-storage": "10Gi",
             ":requests.storage": "40Gi",
+            ":requests.nvidia.com/gpu": "0",
             ":persistentvolumeclaims": "4",
         })
 
@@ -139,12 +141,14 @@ class TestAllocation(base.TestBase):
         utils.set_attribute_on_allocation(allocation, attributes.QUOTA_LIMITS_MEMORY, 8192)
         utils.set_attribute_on_allocation(allocation, attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB, 50)
         utils.set_attribute_on_allocation(allocation, attributes.QUOTA_REQUESTS_STORAGE, 100)
+        utils.set_attribute_on_allocation(allocation, attributes.QUOTA_REQUESTS_GPU, 1)
         utils.set_attribute_on_allocation(allocation, attributes.QUOTA_PVC, 10)
 
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_CPU), 6)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_MEMORY), 8192)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB), 50)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_STORAGE), 100)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_GPU), 1)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_PVC), 10)
 
         # This call should update the openshift quota to match the current attributes
@@ -158,6 +162,7 @@ class TestAllocation(base.TestBase):
             ":limits.memory": "8Gi",
             ":limits.ephemeral-storage": "50Gi",
             ":requests.storage": "100Gi",
+            ":requests.nvidia.com/gpu": "1",
             ":persistentvolumeclaims": "10",
         })
 
@@ -186,6 +191,7 @@ class TestAllocation(base.TestBase):
             ":limits.memory": "8Gi",
             ":limits.ephemeral-storage": "10Gi",
             ":requests.storage": "40Gi",
+            ":requests.nvidia.com/gpu": "0",
             ":persistentvolumeclaims": "4",
         })
 
@@ -204,6 +210,7 @@ class TestAllocation(base.TestBase):
             ":limits.memory": "8Gi",
             ":limits.ephemeral-storage": "10Gi",
             ":requests.storage": "40Gi",
+            ":requests.nvidia.com/gpu": "0",
             ":persistentvolumeclaims": "4",
         })
 


### PR DESCRIPTION
The default GPU quota multiplier should have been 0 given that we don't want a user to have access to a GPU until they explicitly request one via coldfront. Also updated the tests to include requesting an OpenShift GPU.