### PR TITLE
#124 Updated version of account-manager on github action file

### DIFF
--- a/.github/workflows/test-py39-functional-microshift.yaml
+++ b/.github/workflows/test-py39-functional-microshift.yaml
@@ -9,7 +9,7 @@ on:
 env:
   PYTHONWARNINGS: ignore
   KUBECONFIG: ${{ github.workspace }}/kubeconfig
-  ACCT_MGT_VERSION: "44f8f13e4d876249ed2ee1a77fbac86dfd8b3960"
+  ACCT_MGT_VERSION: "6fdbf84e12cf67fc0e288df72788fa77d976ff0e"
 
 jobs:
   build:


### PR DESCRIPTION
Addressing #124, the cause of the microshift test failures was because the action file used an outdated version of the account-management platform. At some point, a feature was added to this cloud-plugin to set quota limits on GPU resources. However, the Github Action file was not appropriately updated.

This is fixed by changing the version of account-management to the latest-in-time, commit 6fdbf84e12cf67fc0e288df72788fa77d976ff0e

Closes #124 