### PR TITLE
Action fix

### DIFF
--- a/.github/workflows/test-py39-functional-microshift.yaml
+++ b/.github/workflows/test-py39-functional-microshift.yaml
@@ -9,7 +9,7 @@ on:
 env:
   PYTHONWARNINGS: ignore
   KUBECONFIG: ${{ github.workspace }}/kubeconfig
-  ACCT_MGT_VERSION: "6fdbf84e12cf67fc0e288df72788fa77d976ff0e"
+  ACCT_MGT_VERSION: "6012025c247ab25fb2cab3be9ad06080e28713ee"
 
 jobs:
   build:


### PR DESCRIPTION
Addressing #91, the Github action file is changed to use the public image on ghcr. The unit tests should pass if the [related PR ](https://github.com/CCI-MOC/openshift-acct-mgt/pull/101)in `acct-manager` is accepted first.