### PR TITLE
explicitly define attribute configuration

### DIFF
--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -1,3 +1,23 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class CloudResourceAttribute:
+    """Class for configuring Cloud Resource Attributes"""
+    name: str
+    type: str = 'Text'
+
+
+@dataclass
+class CloudAllocationAttribute:
+    """Class for configuring Cloud Allocation Attributes"""
+    name: str
+    type: str = 'Int'
+    has_usage: bool = False
+    is_private: bool = False
+    is_changeable: bool = True
+
+
 RESOURCE_AUTH_URL = 'Identity Endpoint URL'
 RESOURCE_ROLE = 'Role for User in Project'
 
@@ -10,24 +30,40 @@ RESOURCE_DEFAULT_NETWORK_CIDR = 'OpenStack Default Network CIDR'
 
 RESOURCE_EULA_URL = "EULA URL"
 
-RESOURCE_ATTRIBUTES = [RESOURCE_AUTH_URL,
-                       RESOURCE_FEDERATION_PROTOCOL,
-                       RESOURCE_IDP,
-                       RESOURCE_PROJECT_DOMAIN,
-                       RESOURCE_ROLE,
-                       RESOURCE_USER_DOMAIN,
-                       RESOURCE_EULA_URL,
-                       RESOURCE_DEFAULT_PUBLIC_NETWORK,
-                       RESOURCE_DEFAULT_NETWORK_CIDR]
+RESOURCE_ATTRIBUTES = [
+    CloudResourceAttribute(name=RESOURCE_AUTH_URL),
+    CloudResourceAttribute(name=RESOURCE_FEDERATION_PROTOCOL),
+    CloudResourceAttribute(name=RESOURCE_IDP),
+    CloudResourceAttribute(name=RESOURCE_PROJECT_DOMAIN),
+    CloudResourceAttribute(name=RESOURCE_ROLE),
+    CloudResourceAttribute(name=RESOURCE_USER_DOMAIN),
+    CloudResourceAttribute(name=RESOURCE_EULA_URL),
+    CloudResourceAttribute(name=RESOURCE_DEFAULT_PUBLIC_NETWORK),
+    CloudResourceAttribute(name=RESOURCE_DEFAULT_NETWORK_CIDR),
+]
 
 # TODO: Migration to rename the OpenStack specific prefix out of these attrs
 ALLOCATION_PROJECT_ID = 'Allocated Project ID'
 ALLOCATION_PROJECT_NAME = 'Allocated Project Name'
 ALLOCATION_INSTITUTION_SPECIFIC_CODE = 'Institution-Specific Code'
 
-ALLOCATION_ATTRIBUTES = [ALLOCATION_PROJECT_ID,
-                         ALLOCATION_PROJECT_NAME,
-                         ALLOCATION_INSTITUTION_SPECIFIC_CODE]
+ALLOCATION_ATTRIBUTES = [
+    CloudAllocationAttribute(
+        name=ALLOCATION_PROJECT_ID,
+        type='Text',
+        is_changeable=False
+    ),
+    CloudAllocationAttribute(
+        name=ALLOCATION_PROJECT_NAME,
+        type='Text',
+        is_changeable=False
+    ),
+    CloudAllocationAttribute(
+        name=ALLOCATION_INSTITUTION_SPECIFIC_CODE,
+        type='Text',
+        is_changeable=False
+    ),
+]
 
 ###########################################################
 # OpenStack Quota Attributes
@@ -54,17 +90,19 @@ QUOTA_REQUESTS_GPU = 'OpenShift Request on GPU Quota'
 QUOTA_PVC = 'OpenShift Persistent Volume Claims Quota'
 
 
-ALLOCATION_QUOTA_ATTRIBUTES = [QUOTA_INSTANCES,
-                               QUOTA_RAM,
-                               QUOTA_VCPU,
-                               QUOTA_VOLUMES,
-                               QUOTA_VOLUMES_GB,
-                               QUOTA_FLOATING_IPS,
-                               QUOTA_OBJECT_GB,
-                               QUOTA_GPU,
-                               QUOTA_LIMITS_CPU,
-                               QUOTA_LIMITS_MEMORY,
-                               QUOTA_LIMITS_EPHEMERAL_STORAGE_GB,
-                               QUOTA_REQUESTS_STORAGE,
-                               QUOTA_REQUESTS_GPU,
-                               QUOTA_PVC]
+ALLOCATION_QUOTA_ATTRIBUTES = [
+    CloudAllocationAttribute(name=QUOTA_INSTANCES),
+    CloudAllocationAttribute(name=QUOTA_RAM),
+    CloudAllocationAttribute(name=QUOTA_VCPU),
+    CloudAllocationAttribute(name=QUOTA_VOLUMES),
+    CloudAllocationAttribute(name=QUOTA_VOLUMES_GB),
+    CloudAllocationAttribute(name=QUOTA_FLOATING_IPS),
+    CloudAllocationAttribute(name=QUOTA_OBJECT_GB),
+    CloudAllocationAttribute(name=QUOTA_GPU),
+    CloudAllocationAttribute(name=QUOTA_LIMITS_CPU),
+    CloudAllocationAttribute(name=QUOTA_LIMITS_MEMORY),
+    CloudAllocationAttribute(name=QUOTA_LIMITS_EPHEMERAL_STORAGE_GB),
+    CloudAllocationAttribute(name=QUOTA_REQUESTS_STORAGE),
+    CloudAllocationAttribute(name=QUOTA_REQUESTS_GPU),
+    CloudAllocationAttribute(name=QUOTA_PVC),
+]

--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -61,7 +61,7 @@ ALLOCATION_ATTRIBUTES = [
     CloudAllocationAttribute(
         name=ALLOCATION_INSTITUTION_SPECIFIC_CODE,
         type='Text',
-        is_changeable=False
+        is_changeable=True
     ),
 ]
 

--- a/src/coldfront_plugin_cloud/management/commands/list_cloud_allocations.py
+++ b/src/coldfront_plugin_cloud/management/commands/list_cloud_allocations.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
 
     def get_cloud_attrs(self, cloud_type):
         attrs = [
-            i for i in attributes.ALLOCATION_QUOTA_ATTRIBUTES if cloud_type in i
+            i for i in attributes.ALLOCATION_QUOTA_ATTRIBUTES if cloud_type in i.name
         ]
         return attrs
 
@@ -78,7 +78,7 @@ class Command(BaseCommand):
             alloc_attrs = []
             for attr in cloud_attrs:
                 try:
-                    alloc_attrs.append(float(allocation.get_attribute(attr)))
+                    alloc_attrs.append(float(allocation.get_attribute(attr.name)))
                 except TypeError:
                     logger.debug(f'!!! TYPE ERROR FOR ATTR {attr} (ALLOCATION: {alloc_id})')
                     alloc_attrs.append(0)
@@ -93,7 +93,7 @@ class Command(BaseCommand):
 
     def render_csv(self, allocations, cloud_type):
         headers = ['pi_email', 'cloud_type', 'project_id', 'project_title', 'alloc_id']
-        headers = headers + [i.replace(' ', '_') for i in self.get_cloud_attrs(cloud_type)]
+        headers = headers + [i.name.replace(' ', '_') for i in self.get_cloud_attrs(cloud_type)]
         f = csv.writer(sys.stdout)
         allocations.insert(0, headers)
         f.writerows(allocations)

--- a/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
+++ b/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
@@ -74,28 +74,28 @@ class Command(BaseCommand):
                              f' Cannot perform automatic migration.')
 
     def register_allocation_attributes(self):
-        def register(attribute_name, attribute_type):
+        alloc_attrs = (
+            attributes.ALLOCATION_ATTRIBUTES +
+            attributes.ALLOCATION_QUOTA_ATTRIBUTES
+        )
+
+        for attr in alloc_attrs:
             allocation_models.AllocationAttributeType.objects.get_or_create(
-                name=attribute_name,
+                name=attr.name,
                 attribute_type=allocation_models.AttributeType.objects.get(
-                    name=attribute_type),
-                has_usage=False,
-                is_private=False,
-                is_changeable='Quota' in attribute_name
+                    name=attr.type,
+                ),
+                has_usage=attr.has_usage,
+                is_private=attr.is_private,
+                is_changeable=attr.is_changeable,
             )
 
-        for allocation_attribute in attributes.ALLOCATION_ATTRIBUTES:
-            register(allocation_attribute, 'Text')
-
-        for allocation_quota_attribute in attributes.ALLOCATION_QUOTA_ATTRIBUTES:
-            register(allocation_quota_attribute, 'Int')
-
     def register_resource_attributes(self):
-        for resource_attribute_type in attributes.RESOURCE_ATTRIBUTES:
+        for attr in attributes.RESOURCE_ATTRIBUTES:
             resource_models.ResourceAttributeType.objects.get_or_create(
-                name=resource_attribute_type,
+                name=attr.name,
                 attribute_type=resource_models.AttributeType.objects.get(
-                    name='Text')
+                    name=attr.type),
             )
 
     def register_resource_type(self):

--- a/src/coldfront_plugin_cloud/management/commands/validate_allocations.py
+++ b/src/coldfront_plugin_cloud/management/commands/validate_allocations.py
@@ -101,28 +101,28 @@ class Command(BaseCommand):
             failed_validation = Command.sync_users(project_id, allocation, allocator, options["apply"])
 
             for attr in attributes.ALLOCATION_QUOTA_ATTRIBUTES:
-                if 'OpenStack' in attr:
-                    key = openstack.QUOTA_KEY_MAPPING_ALL_KEYS.get(attr, None)
+                if 'OpenStack' in attr.name:
+                    key = openstack.QUOTA_KEY_MAPPING_ALL_KEYS.get(attr.name, None)
                     if not key:
                         # Note(knikolla): Some attributes are only maintained
                         # for bookkeeping purposes and do not have a
                         # corresponding quota set on the service.
                         continue
 
-                    expected_value = allocation.get_attribute(attr)
+                    expected_value = allocation.get_attribute(attr.name)
                     current_value = quota.get(key, None)
                     if expected_value is None and current_value:
-                        msg = (f'Attribute "{attr}" expected on allocation {allocation_str} but not set.'
+                        msg = (f'Attribute "{attr.name}" expected on allocation {allocation_str} but not set.'
                                f' Current quota is {current_value}.')
                         if options['apply']:
                             utils.set_attribute_on_allocation(
-                                allocation, attr, current_value
+                                allocation, attr.name, current_value
                             )
                             msg = f'{msg} Attribute set to match current quota.'
                         logger.warning(msg)
                     elif not current_value == expected_value:
                         failed_validation = True
-                        msg = (f'Value for quota for {attr} = {current_value} does not match expected'
+                        msg = (f'Value for quota for {attr.name} = {current_value} does not match expected'
                                f' value of {expected_value} on allocation {allocation_str}')
                         logger.warning(msg)
 
@@ -173,13 +173,13 @@ class Command(BaseCommand):
             failed_validation = Command.sync_users(project_id, allocation, allocator, options["apply"])
 
             for attr in attributes.ALLOCATION_QUOTA_ATTRIBUTES:
-                if "OpenShift" in attr:
-                    key_with_lambda = openshift.QUOTA_KEY_MAPPING.get(attr, None)
+                if "OpenShift" in attr.name:
+                    key_with_lambda = openshift.QUOTA_KEY_MAPPING.get(attr.name, None)
 
                     # This gives me just the plain key
                     key = list(key_with_lambda(1).keys())[0]
 
-                    expected_value = allocation.get_attribute(attr)
+                    expected_value = allocation.get_attribute(attr.name)
                     current_value = quota.get(key, None)
 
                     PATTERN = r"([0-9]+)(m|Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?"
@@ -205,7 +205,7 @@ class Command(BaseCommand):
 
                         if result is None:
                             raise CommandError(
-                                f"Unable to parse current_value = '{current_value}' for {attr}"
+                                f"Unable to parse current_value = '{current_value}' for {attr.name}"
                             )
 
                         value = int(result.groups()[0])
@@ -220,25 +220,25 @@ class Command(BaseCommand):
 
                         # Convert some attributes to units that coldfront uses
 
-                        if "RAM" in attr:
+                        if "RAM" in attr.name:
                             current_value = round(current_value / suffix["Mi"])
-                        elif "Storage" in attr:
+                        elif "Storage" in attr.name:
                             current_value = round(current_value / suffix["Gi"])
 
                     if expected_value is None and current_value:
                         msg = (
-                            f'Attribute "{attr}" expected on allocation {allocation_str} but not set.'
+                            f'Attribute "{attr.name}" expected on allocation {allocation_str} but not set.'
                             f" Current quota is {current_value}."
                         )
                         if options["apply"]:
                             utils.set_attribute_on_allocation(
-                                allocation, attr, current_value
+                                allocation, attr.name, current_value
                             )
                             msg = f"{msg} Attribute set to match current quota."
                         logger.warning(msg)
                     elif not (current_value == expected_value):
                         msg = (
-                            f"Value for quota for {attr} = {current_value} does not match expected"
+                            f"Value for quota for {attr.name} = {current_value} does not match expected"
                             f" value of {expected_value} on allocation {allocation_str}"
                         )
                         logger.warning(msg)

--- a/src/coldfront_plugin_cloud/tests/functional/openstack/test_allocation.py
+++ b/src/coldfront_plugin_cloud/tests/functional/openstack/test_allocation.py
@@ -109,8 +109,8 @@ class TestAllocation(base.TestBase):
 
         # Check correct attributes
         for attr in attributes.ALLOCATION_QUOTA_ATTRIBUTES:
-            if 'OpenStack' in attr:
-                self.assertIsNotNone(allocation.get_attribute(attr))
+            if 'OpenStack' in attr.name:
+                self.assertIsNotNone(allocation.get_attribute(attr.name))
 
     def test_new_allocation_with_quantity(self):
         user = self.new_user()


### PR DESCRIPTION
This patch explicitly defines all attribute configuration in the coldfront_plugin_cloud.attributes module. Previously, these settings were implied by conventions around the naming and organization of the attributes within the attributes module. This makes it easier to handle additional use cases as requirements change over time.

This patch also introduces two new dataclasses, `CloudResourceAttribute` and `CloudAllocationAttribute`, for storing both the attribute name and settings. The `RESOURCE_ATTRIBUTES`, `ALLOCATION_ATTRIBUTES`, and `ALLOCATION_QUOTA_ATTRIBUTES` lists are now lists of these dataclasses.

The second commit in this PR makes the institution-specific code attribute editable which was missed in #138