### PR TITLE
Enable uploading generated invoice to S3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto3
 coldfront >= 1.0.4
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient


### PR DESCRIPTION
Introduces the options
* `--upload-to-s3` which will upload the generated CSV from `coldfront calculate_storage_gb_hours`.
* `--s3-endpoint-url` and `--s3-bucket` to configure the destination S3 compatible store and bucket.
* `--invoice-month` which defaults to the month of the start date. This replaces the first column which was Interval.

Additionally
* Provides default for --start -> yesterday
* Provides default for --end -> today

Requires setting the environment variables
* S3_INVOICING_ACCESS_KEY_ID
* S3_INVOICING_SECRET_ACCESS_KEY

It will upload two copies of the invoice using the below format (one for archiving and timestamped and one as a working copy)

/Invoices/<INVOICE_MONTH>/Service Invoices/<SERVICE> <INVOICE_MONTH>.csv /Invoices/<INVOICE_MONTH>/Archive/<SERVICE> <INVOICE_MONTH> <TIMESTAMP>.csv

Where Timestamp is the time at generation using the ISO8601 format and without any special characters. See example below.

For example, for November 2023.

/Invoices/2023-11/Service Invoices/NERC OpenStack 2023-11.csv /Invoices/2023-11/Service Invoices/NERC OpenShift 2023-11.csv /Invoices/2023-11/Service Invoices/NERC Storage 2023-11.csv /Invoices/2023-11/Archive/NERC OpenStack 2023-11 20231218T201706Z.csv /Invoices/2023-11/Archive/NERC OpenShift 2023-11 20231218T201706Z.csv /Invoices/2023-11/Archive/NERC Storage 2023-11 20231218T201706Z.csv

Tooling for OpenStack and OpenShift invoicing is already able to upload files using the above described conventions.