### PR TITLE
rhods: add modelmesh-server label

### DIFF
--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -151,7 +151,10 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         headers = {"Content-type": "application/json"}
         annotations = {"cf_project_id": str(self.allocation.project_id),
                        "cf_pi": self.allocation.project.pi.username}
-        labels = {'opendatahub.io/dashboard': "true"}
+        labels = {
+            'opendatahub.io/dashboard': "true",
+            'modelmesh-enabled': "true",
+        }
 
         payload = {"displayName": project_name,
                    "annotations": annotations,


### PR DESCRIPTION
This adds the `modelmesh-enabled: true` label to all new projects by default. This is another rhods-specific label required in order to use a model mesh server within RHODS. Without it users run into errors similar to the following:

> pods "modelmesh-serving-saas-7994599679-" is forbidden: error looking up service account software-application-innovation-lab-sail-projects-fcd6dfa/modelmesh-serving-sa: serviceaccount "modelmesh-serving-sa" not found
