### PR TITLE
Integrate ESI into Coldfront

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,14 @@ dashboard or through the helper command:
 
 ```bash
 $ coldfront add_openstack_resource
-usage: coldfront add_openstack_resource [-h] --name NAME --auth-url AUTH_URL [--users-domain USERS_DOMAIN] [--projects-domain PROJECTS_DOMAIN] --idp IDP
-                                        [--protocol PROTOCOL] [--role ROLE] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback]
-                                        [--no-color] [--force-color]
+usage: coldfront add_openstack_resource [-h] --name NAME --auth-url AUTH_URL [--users-domain USERS_DOMAIN] [--projects-domain PROJECTS_DOMAIN] --idp IDP [--protocol PROTOCOL] [--role ROLE]
+                                        [--public-network PUBLIC_NETWORK] [--network-cidr NETWORK_CIDR] [--esi] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback]
+                                        [--no-color] [--force-color] [--skip-checks]
 coldfront add_openstack_resource: error: the following arguments are required: --name, --auth-url, --idp
 ```
+
+An Openstack resource can be specified as an ESI resource by setting the `--esi` command flag.
+ESI resource allocations will only have quotas for network resources by default.
 
 ### Configuring for OpenShift
 

--- a/ci/run_functional_tests_openstack.sh
+++ b/ci/run_functional_tests_openstack.sh
@@ -13,6 +13,9 @@ export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_SECRET=$(
 export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID=$(
     openstack application credential show "$credential_name" -f value -c id)
 
+export OPENSTACK_ESI_APPLICATION_CREDENTIAL_SECRET=$OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_SECRET
+export OPENSTACK_ESI_APPLICATION_CREDENTIAL_ID=$OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID
+
 export OPENSTACK_PUBLIC_NETWORK_ID=$(openstack network show public -f value -c id)
 
 if [[ ! "${CI}" == "true" ]]; then
@@ -28,6 +31,7 @@ export KEYCLOAK_PASS="nomoresecret"
 export KEYCLOAK_REALM="master"
 
 coverage run --source="." -m django test coldfront_plugin_cloud.tests.functional.openstack
+coverage run --source="." -m django test coldfront_plugin_cloud.tests.functional.esi
 coverage report
 
 openstack application credential delete $OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID

--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -75,6 +75,7 @@ QUOTA_VOLUMES = 'OpenStack Number of Volumes Quota'
 QUOTA_VOLUMES_GB = 'OpenStack Volume Quota (GiB)'
 
 QUOTA_FLOATING_IPS = 'OpenStack Floating IP Quota'
+QUOTA_NETWORKS = 'Openstack Network Quota'
 
 QUOTA_OBJECT_GB = 'OpenStack Swift Quota (GiB)'
 
@@ -96,6 +97,7 @@ ALLOCATION_QUOTA_ATTRIBUTES = [
     CloudAllocationAttribute(name=QUOTA_VCPU),
     CloudAllocationAttribute(name=QUOTA_VOLUMES),
     CloudAllocationAttribute(name=QUOTA_VOLUMES_GB),
+    CloudAllocationAttribute(name=QUOTA_NETWORKS),
     CloudAllocationAttribute(name=QUOTA_FLOATING_IPS),
     CloudAllocationAttribute(name=QUOTA_OBJECT_GB),
     CloudAllocationAttribute(name=QUOTA_GPU),

--- a/src/coldfront_plugin_cloud/esi.py
+++ b/src/coldfront_plugin_cloud/esi.py
@@ -1,0 +1,29 @@
+import logging
+import functools
+import os
+
+from keystoneauth1.identity import v3
+from keystoneauth1 import session
+
+from coldfront_plugin_cloud import attributes, utils
+from coldfront_plugin_cloud.openstack import OpenStackResourceAllocator
+
+class ESIResourceAllocator(OpenStackResourceAllocator):
+
+    QUOTA_KEY_MAPPING = {
+        'network': {
+            'keys': {
+                attributes.QUOTA_FLOATING_IPS: 'floatingip',
+                attributes.QUOTA_NETWORKS: 'network'
+            }
+        }
+    }
+
+    QUOTA_KEY_MAPPING_ALL_KEYS = {quota_key: quota_name for k in QUOTA_KEY_MAPPING.values() for quota_key, quota_name in k['keys'].items()}
+
+    resource_type = 'esi'
+
+    def get_quota(self, project_id):
+        quotas = dict()
+        quotas = self._get_network_quota(quotas, project_id)
+        return quotas

--- a/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
+++ b/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
@@ -126,6 +126,9 @@ class Command(BaseCommand):
         resource_models.ResourceType.objects.get_or_create(
             name='OpenShift', description='OpenShift Cloud'
         )
+        resource_models.ResourceType.objects.get_or_create(
+            name='ESI', description='ESI Bare Metal Cloud'
+        )
 
     def handle(self, *args, **options):
         self.register_resource_type()

--- a/src/coldfront_plugin_cloud/tasks.py
+++ b/src/coldfront_plugin_cloud/tasks.py
@@ -10,6 +10,7 @@ from coldfront_plugin_cloud import (attributes,
                                     base,
                                     openstack,
                                     openshift,
+                                    esi,
                                     utils)
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,10 @@ UNIT_QUOTA_MULTIPLIERS = {
         attributes.QUOTA_REQUESTS_STORAGE: 20,
         attributes.QUOTA_REQUESTS_GPU: 0,
         attributes.QUOTA_PVC: 2
+    },
+    'esi': {
+        attributes.QUOTA_FLOATING_IPS: 0,
+        attributes.QUOTA_NETWORKS: 0
     }
 }
 
@@ -48,6 +53,10 @@ STATIC_QUOTA = {
     },
     'openshift': {
         attributes.QUOTA_REQUESTS_GPU: 0,
+    },
+    'esi': {
+        attributes.QUOTA_FLOATING_IPS: 1,
+        attributes.QUOTA_NETWORKS: 1
     }
 }
 
@@ -56,6 +65,7 @@ def find_allocator(allocation) -> base.ResourceAllocator:
     allocators = {
         'openstack': openstack.OpenStackResourceAllocator,
         'openshift': openshift.OpenShiftResourceAllocator,
+        'esi': esi.ESIResourceAllocator,
     }
     # TODO(knikolla): It doesn't seem to be possible to select multiple resources
     # when requesting a new allocation, so why is this multivalued?

--- a/src/coldfront_plugin_cloud/tests/base.py
+++ b/src/coldfront_plugin_cloud/tests/base.py
@@ -41,9 +41,9 @@ class TestBase(TestCase):
         username = username or f'{uuid.uuid4().hex}@example.com'
         User.objects.create(username=username, email=username)
         return User.objects.get(username=username)
-
+    
     @staticmethod
-    def new_resource(name=None, auth_url=None) -> Resource:
+    def new_esi_resource(name=None, auth_url=None) -> Resource:
         resource_name = name or uuid.uuid4().hex
 
         call_command(
@@ -57,6 +57,26 @@ class TestBase(TestCase):
              role='member',
              public_network=os.getenv('OPENSTACK_PUBLIC_NETWORK_ID'),
              network_cidr='192.168.0.0/24',
+             esi=True
+        )
+        return Resource.objects.get(name=resource_name)
+
+    @staticmethod
+    def new_openstack_resource(name=None, auth_url=None) -> Resource:
+        resource_name = name or uuid.uuid4().hex
+
+        call_command(
+            'add_openstack_resource',
+             name=resource_name,
+             auth_url=auth_url or f'https://{resource_name}/identity/v3',
+             projects_domain='default',
+             users_domain='default',
+             idp='sso',
+             protocol='openid',
+             role='member',
+             public_network=os.getenv('OPENSTACK_PUBLIC_NETWORK_ID'),
+             network_cidr='192.168.0.0/24',
+             esi=False
         )
         return Resource.objects.get(name=resource_name)
 

--- a/src/coldfront_plugin_cloud/tests/functional/esi/test_allocations.py
+++ b/src/coldfront_plugin_cloud/tests/functional/esi/test_allocations.py
@@ -1,0 +1,128 @@
+import os
+import unittest
+import uuid
+import time
+
+from coldfront_plugin_cloud import attributes, openstack, esi, tasks
+from coldfront_plugin_cloud.tests import base
+
+from django.core.management import call_command
+from keystoneclient.v3 import client
+from cinderclient import client as cinderclient
+from neutronclient.v2_0 import client as neutronclient
+from novaclient import client as novaclient
+
+@unittest.skipUnless(os.getenv('FUNCTIONAL_TESTS'), 'Functional tests not enabled.')
+class TestAllocation(base.TestBase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resource = self.new_esi_resource(name='ESI',
+                                          auth_url=os.getenv('OS_AUTH_URL'))
+        self.session = openstack.get_session_for_resource(self.resource)
+        self.identity = client.Client(session=self.session)
+        self.compute = novaclient.Client(session=self.session, version=2)
+        self.volume = cinderclient.Client(session=self.session, version=3)
+        self.networking = neutronclient.Client(session=self.session)
+        self.role_member = self.identity.roles.find(name='member')
+
+    def test_new_ESI_allocation(self):
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 1)
+        allocator = esi.ESIResourceAllocator(self.resource, 
+                                             allocation)
+
+        tasks.activate_allocation(allocation.pk)
+        allocation.refresh_from_db()
+
+        # Check project
+        project_id = allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID)
+        self.assertIsNotNone(project_id)
+        self.assertIsNotNone(allocation.get_attribute(attributes.ALLOCATION_PROJECT_NAME))
+
+        openstack_project = self.identity.projects.get(project_id)
+        self.assertTrue(openstack_project.enabled)
+
+        # Check user and roles
+        openstack_user = allocator.get_federated_user(user.username)
+        openstack_user = self.identity.users.get(openstack_user['id'])
+
+        roles = self.identity.role_assignments.list(user=openstack_user.id,
+                                                    project=openstack_project.id)
+
+        self.assertEqual(len(roles), 1)
+        self.assertEqual(roles[0].role['id'], self.role_member.id)
+
+        # Check default network
+        time.sleep(5)
+        network = self.networking.list_networks(
+            project_id=project_id, name='default_network')['networks'][0]
+        router = self.networking.list_routers(
+            project_id=project_id, name='default_router')['routers'][0]
+        ports = self.networking.list_ports(project_id=project_id,
+                                           network_id=network['id'],
+                                           device_id=router['id'])['ports']
+        self.assertIsNotNone(ports)
+        self.assertEqual(ports[0]['status'], 'ACTIVE')
+
+        # Validate get_quota
+        expected_quota = {
+            'floatingip': 1,
+            'network': 1,
+        }
+        resulting_quota = allocator.get_quota(openstack_project.id)
+        self.assertEqual(expected_quota, resulting_quota)
+
+    def test_add_remove_user(self):
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        project_user = self.new_project_user(user, project)
+        allocation = self.new_allocation(project, self.resource, 1)
+        allocation_user = self.new_allocation_user(allocation, user)
+        allocator = esi.ESIResourceAllocator(self.resource,
+                                                allocation)
+
+        user2 = self.new_user()
+        project_user2 = self.new_project_user(user2, project)
+        allocation_user2 = self.new_allocation_user(allocation, user2)
+
+        tasks.activate_allocation(allocation.pk)
+        allocation.refresh_from_db()
+
+        project_id = allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID)
+        openstack_project = self.identity.projects.get(project_id)
+
+        tasks.add_user_to_allocation(allocation_user2.pk)
+
+        openstack_user = allocator.get_federated_user(user2.username)
+        openstack_user = self.identity.users.get(openstack_user['id'])
+
+        roles = self.identity.role_assignments.list(user=openstack_user.id,
+                                                    project=openstack_project.id)
+
+        self.assertEqual(len(roles), 1)
+        self.assertEqual(roles[0].role['id'], self.role_member.id)
+        assert set([user.username, user2.username]) == allocator.get_users(project_id)
+
+        tasks.remove_user_from_allocation(allocation_user2.pk)
+
+        roles = self.identity.role_assignments.list(user=openstack_user.id,
+                                                    project=openstack_project.id)
+
+        self.assertEqual(len(roles), 0)
+        assert set([user.username]) == allocator.get_users(project_id)
+
+        # use the validate_allocations command to add a new user
+        user3 = self.new_user()
+        allocation_user3 = self.new_allocation_user(allocation, user3)
+        assert user3.username not in allocator.get_users(project_id)
+        call_command('validate_allocations', apply=True)
+        assert user3.username in allocator.get_users(project_id)
+
+        non_coldfront_user = uuid.uuid4().hex
+        allocator.get_or_create_federated_user(non_coldfront_user)
+        allocator.assign_role_on_user(non_coldfront_user, project_id)
+        assert non_coldfront_user in allocator.get_users(project_id)
+        call_command('validate_allocations', apply=True)
+        assert non_coldfront_user not in allocator.get_users(project_id)

--- a/src/coldfront_plugin_cloud/tests/functional/openstack/test_allocation.py
+++ b/src/coldfront_plugin_cloud/tests/functional/openstack/test_allocation.py
@@ -18,7 +18,7 @@ class TestAllocation(base.TestBase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.resource = self.new_resource(name='Devstack',
+        self.resource = self.new_openstack_resource(name='Devstack',
                                           auth_url=os.getenv('OS_AUTH_URL'))
         self.session = openstack.get_session_for_resource(self.resource)
         self.identity = client.Client(session=self.session)
@@ -207,7 +207,7 @@ class TestAllocation(base.TestBase):
 
         # Change allocation attributes for object store quota
         current_quota = allocator.get_quota(openstack_project.id)
-        obj_key = openstack.QUOTA_KEY_MAPPING['object']['keys'][attributes.QUOTA_OBJECT_GB]
+        obj_key = openstack.OpenStackResourceAllocator.QUOTA_KEY_MAPPING['object']['keys'][attributes.QUOTA_OBJECT_GB]
         if obj_key in current_quota.keys():
             utils.set_attribute_on_allocation(allocation, attributes.QUOTA_OBJECT_GB, 6)
             self.assertEqual(allocation.get_attribute(attributes.QUOTA_OBJECT_GB), 6)

--- a/src/coldfront_plugin_cloud/tests/unit/test_attribute_migration.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_attribute_migration.py
@@ -154,7 +154,7 @@ class TestAttributeMigration(base.TestBase):
                 ):
 
                     call_command('register_cloud_attributes')
-                    resource = self.new_resource('Example', auth_url_val)
+                    resource = self.new_openstack_resource('Example', auth_url_val)
 
                     self.assertEqual(
                         resource.get_attribute(new_auth_url_name),


### PR DESCRIPTION
Closes #135 To integrate ESI and make use of the existing code, I have made a few small restructuring choices. There’s too many to list, so I will be ready for everyone’s questions on my code changes. 

The ESI allocator object, implemented in `esi.py`, subclasses from the Openstack allocator, with a few functions overridden. The ESI allocator only makes quotas for floating IPs and networks. The appropriate Allocation Attributes have been added to `attributes.py`

The functional test for the ESI integration uses the same Openstack cluster put up by `test-py38-functional-devstack.yaml`. `ci/run_functional_tests_openstack.sh` has been edited to also create an ESI coldfront resource and to run the ESI functional tests.