### PR TITLE
Migrating to using upstream keystone oidc plugin

### DIFF
--- a/ci/devstack-config-ip.sh
+++ b/ci/devstack-config-ip.sh
@@ -1,0 +1,2 @@
+HOST_IP=`ip addr show eth0 | grep "inet " | awk '{ print $2 }' | awk -F "/"  '{ print $1 }'`
+HOST_IPV6=`ip addr show eth0 | grep "inet6 " | awk '{ print $2 }' | awk -F "/"  '{ print $1 }'`

--- a/ci/devstack-mapping.json
+++ b/ci/devstack-mapping.json
@@ -1,0 +1,22 @@
+[
+    {
+        "local": [
+            {
+                "user": {
+                    "name": "{0}"
+                },
+                "group": {
+                    "name": "federated_users",
+                    "domain": {
+                        "name": "federated_domain"
+                    }
+                }
+            }
+        ],
+        "remote": [
+            {
+                "type": "OIDC-preferred_username"
+            }
+        ]
+    }
+]

--- a/ci/devstack-test-oidc.py
+++ b/ci/devstack-test-oidc.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+from keystoneauth1 import identity
+from keystoneauth1 import session
+
+host_ip = os.getenv('HOST_IP', 'localhost')
+auth = identity.v3.oidc.OidcPassword(
+    f'http://{host_ip}/identity/v3',
+    identity_provider='sso',
+    protocol='openid',
+    client_id='devstack',
+    client_secret='nomoresecret',
+    access_token_endpoint=f'https://{host_ip}:8443/realms/master/protocol/openid-connect/token',
+    discovery_endpoint=f'https://{host_ip}:8443/realms/master/.well-known/openid-configuration',
+    username='admin',
+    password='nomoresecret',
+    project_name='federated_project',
+    project_domain_name='federated_domain',
+)
+s = session.Session(auth)
+
+if s.get_token():
+    print('Authentication successful!')
+else:
+    sys.exit('OpenID Authentication failed')

--- a/ci/devstack.sh
+++ b/ci/devstack.sh
@@ -2,6 +2,7 @@
 # Installs Devstack with the OIDC plugin
 #
 set -xe
+REPO_PATH=$PWD
 
 sudo apt-get update
 # sudo apt-get upgrade -y
@@ -9,15 +10,13 @@ sudo apt-get update
 sudo mkdir -p /opt/stack
 sudo chown "$USER:$USER" /opt/stack
 
-if [[ ! "${CI}" == "true" ]]; then
-    sudo apt-get install docker.io docker-compose -y
-fi
-
-git clone https://github.com/knikolla/devstack-plugin-oidc /opt/stack/devstack-plugin-oidc
-source /opt/stack/devstack-plugin-oidc/tools/config.sh
-
-# Start Keycloak
-cd /opt/stack/devstack-plugin-oidc/tools && sudo docker-compose up -d
+# Install CA into keycloak container and host
+mkdir /opt/stack/data
+cd /opt/stack/data
+openssl req -x509 -nodes -newkey rsa:2048 -keyout key.pem -out cert.pem -sha256 -subj "/CN=$(hostname -I | awk '{print $1}')"
+cat cert.pem key.pem > devstack-cert.pem
+sudo cp devstack-cert.pem /usr/local/share/ca-certificates/devstack-cert.crt
+sudo update-ca-certificates
 
 # Install and start Devstack
 git clone https://github.com/openstack/devstack.git /opt/stack/devstack
@@ -44,17 +43,23 @@ echo "
     IP_VERSION=4
     GIT_DEPTH=1
     GIT_BASE=https://github.com
-    KEYSTONE_ADMIN_ENDPOINT=True
-    enable_plugin devstack-plugin-oidc https://github.com/knikolla/devstack-plugin-oidc main
+    enable_plugin keystone https://github.com/openstack/keystone
+    enable_service keystone-oidc-federation
 
     SWIFT_DEFAULT_BIND_PORT=8085
     SWIFT_DEFAULT_BIND_PORT_INT=8086
 " >> local.conf
-./stack.sh
-
-python3 /opt/stack/devstack-plugin-oidc/tools/test_login.py
+./stack.sh  
 
 source /opt/stack/devstack/openrc admin admin
 
 # Create role implication to allow admin to admin on Swift
 openstack implied role create admin --implied-role ResellerAdmin
+
+# Create oidc protocol and mappings to register keycloak identity provider
+openstack mapping create --rules $REPO_PATH/ci/devstack-mapping.json sso_oidc_mapping
+openstack federation protocol create --identity-provider sso --mapping sso_oidc_mapping openid
+
+# Test OIDC plugin with keycloak
+source $REPO_PATH/ci/devstack-config-ip.sh
+HOST_IP=$HOST_IP python3 $REPO_PATH/ci/devstack-test-oidc.py test_oidc_login.py

--- a/ci/run_functional_tests_openstack.sh
+++ b/ci/run_functional_tests_openstack.sh
@@ -2,8 +2,8 @@
 #
 # Tests expect the resource to be name Devstack
 set -xe
-
-source /opt/stack/devstack-plugin-oidc/tools/config.sh
+REPO_PATH=$PWD
+source $REPO_PATH/ci/devstack-config-ip.sh 
 source /opt/stack/devstack/openrc admin admin
 
 credential_name=$(openssl rand -base64 12)

--- a/src/coldfront_plugin_cloud/tests/functional/openstack/test_allocation.py
+++ b/src/coldfront_plugin_cloud/tests/functional/openstack/test_allocation.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import uuid
+import time
 
 from coldfront_plugin_cloud import attributes, openstack, tasks, utils
 from coldfront_plugin_cloud.tests import base
@@ -55,6 +56,8 @@ class TestAllocation(base.TestBase):
         self.assertEqual(roles[0].role['id'], self.role_member.id)
 
         # Check default network
+        # Port build-up time is not instant
+        time.sleep(5)
         network = self.networking.list_networks(
             project_id=project_id, name='default_network')['networks'][0]
         router = self.networking.list_routers(


### PR DESCRIPTION
Closes #149 I edited the devstack functional test to use upstream Keystone's OIDC plugin. A few files from the [old plugin repo](https://github.com/knikolla/devstack-plugin-oidc) were copied and embedded in devstack.sh since I don't know a better place to put them. I am happy to relocate these files given advice.

it is important to note that sometimes the functional test for Openstack fails because one of the [plugin's setup script ](https://github.com/openstack/keystone/blob/4121cf6cb7c3d5e585df827d72e08296664f7326/devstack/tools/oidc/setup_keycloak_client.py#L29)would fail to access an endpoint in the Keycloak container. I am currently investigating the cause, or at least a solution to this failure.