### PR TITLE
Fix missing dependency, incorrect string quotes and argparse method

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
+    boto3
     coldfront >= 1.0.4
     python-cinderclient
     python-keystoneclient

--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -93,7 +93,7 @@ class Command(BaseCommand):
                             default='https://s3.us-east-005.backblazeb2.com')
         parser.add_argument('--s3-bucket-name', type=str,
                             default='nerc-invoicing')
-        parser.add_option('--upload-to-s3',
+        parser.add_argument('--upload-to-s3', default=False, action='store_true',
                           help='Upload generated CSV invoice to S3 storage.')
 
     @staticmethod
@@ -219,7 +219,7 @@ class Command(BaseCommand):
                 )
 
         if options['upload_to_s3']:
-            logger.info(f'Uploading to S3 endpoint {options['s3_endpoint_url']}.')
+            logger.info(f'Uploading to S3 endpoint {options["s3_endpoint_url"]}.')
             self.upload_to_s3(options['s3_endpoint_url'],
                               options['s3_bucket'],
                               options['output'],


### PR DESCRIPTION
- setup.cfg was missing the `boto3` library, therefore it wasn't installed in the `coldfront-nerc` container.
- String quotes were incorrect in one instance, causing the script to fail.
- Auto-complete suggested `add_option` confusing argparse for optparse. Fixed correct usage for argparse, changing the method from add_option to add_argument.