### PR TITLE
validate: fix object store quota value comparison

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/validate_allocations.py
+++ b/src/coldfront_plugin_cloud/management/commands/validate_allocations.py
@@ -120,7 +120,7 @@ class Command(BaseCommand):
                     current_value = quota.get(key, None)
                     if key == obj_key and expected_value <= 0:
                         expected_obj_value = 1
-                        current_value = allocator.object(project_id).head_account().get(obj_key)
+                        current_value = int(allocator.object(project_id).head_account().get(obj_key))
                         if current_value != expected_obj_value:
                             failed_validation = True
                             msg = (f'Value for quota for {attr.name} = {current_value} does not match expected'


### PR DESCRIPTION
The quota value returned from swift's head_account function returns a string not an integer.