### PR TITLE
Added rounding to Cost and Rate for storage invoice

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -1,5 +1,5 @@
 import csv
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 import dataclasses
 from datetime import datetime, timedelta
 import logging
@@ -161,7 +161,7 @@ class Command(BaseCommand):
                     Invoice_Type_Hours=time,
                     Invoice_Type=su_name,
                     Rate=rate,
-                    Cost=time * rate
+                    Cost=(time * rate).quantize(Decimal('.01'), rounding=ROUND_HALF_UP)
                 )
                 csv_invoice_writer.writerow(
                     row.get_values()


### PR DESCRIPTION
Closes #157, Cost will now be rounded to 2 decimal points
Rate will be rounded to 6 decimal points, since the Openshift Gb/hr rates at the time of this commit is $0.000009