### PR TITLE
renamed the attributes with GiB and MiB removing GB and MB

### DIFF
--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -68,24 +68,24 @@ ALLOCATION_ATTRIBUTES = [
 ###########################################################
 # OpenStack Quota Attributes
 QUOTA_INSTANCES = 'OpenStack Compute Instance Quota'
-QUOTA_RAM = 'OpenStack Compute RAM Quota'
+QUOTA_RAM = 'OpenStack Compute RAM Quota (MiB)'
 QUOTA_VCPU = 'OpenStack Compute vCPU Quota'
 
 QUOTA_VOLUMES = 'OpenStack Volume Quota'
-QUOTA_VOLUMES_GB = 'OpenStack Volume GB Quota'
+QUOTA_VOLUMES_GB = 'OpenStack Volume Quota (GiB)'
 
 QUOTA_FLOATING_IPS = 'OpenStack Floating IP Quota'
 
-QUOTA_OBJECT_GB = 'OpenStack Swift Quota in Gigabytes'
+QUOTA_OBJECT_GB = 'OpenStack Swift Quota (GiB)'
 
 QUOTA_GPU = 'OpenStack GPU Quota'
 
 ###########################################################
 # OpenShift Quota Attributes
 QUOTA_LIMITS_CPU = 'OpenShift Limit on CPU Quota'
-QUOTA_LIMITS_MEMORY = 'OpenShift Limit on RAM Quota (MB)'
-QUOTA_LIMITS_EPHEMERAL_STORAGE_GB = 'OpenShift Limit on Ephemeral Storage Quota (GB)'
-QUOTA_REQUESTS_STORAGE = 'OpenShift Request on Storage Quota (GB)'
+QUOTA_LIMITS_MEMORY = 'OpenShift Limit on RAM Quota (MiB)'
+QUOTA_LIMITS_EPHEMERAL_STORAGE_GB = 'OpenShift Limit on Ephemeral Storage Quota (GiB)'
+QUOTA_REQUESTS_STORAGE = 'OpenShift Request on Storage Quota (GiB)'
 QUOTA_REQUESTS_GPU = 'OpenShift Request on GPU Quota'
 QUOTA_PVC = 'OpenShift Persistent Volume Claims Quota'
 

--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -71,7 +71,7 @@ QUOTA_INSTANCES = 'OpenStack Compute Instance Quota'
 QUOTA_RAM = 'OpenStack Compute RAM Quota (MiB)'
 QUOTA_VCPU = 'OpenStack Compute vCPU Quota'
 
-QUOTA_VOLUMES = 'OpenStack Volume Quota'
+QUOTA_VOLUMES = 'OpenStack Number of Volumes Quota'
 QUOTA_VOLUMES_GB = 'OpenStack Volume Quota (GiB)'
 
 QUOTA_FLOATING_IPS = 'OpenStack Floating IP Quota'

--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -76,7 +76,7 @@ QUOTA_VOLUMES_GB = 'OpenStack Volume Quota (GiB)'
 
 QUOTA_FLOATING_IPS = 'OpenStack Floating IP Quota'
 
-QUOTA_OBJECT_GB = 'OpenStack Swift Quota (GiB)'
+QUOTA_OBJECT_GB = 'OpenStack Swift Quota in Gigabytes'
 
 QUOTA_GPU = 'OpenStack GPU Quota'
 

--- a/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
+++ b/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
@@ -25,6 +25,9 @@ ALLOCATION_ATTRIBUTE_MIGRATIONS = [
     ('OpenShift Limit on RAM Quota', {
         'name': 'OpenShift Limit on RAM Quota (MB)'
     }),
+    ('OpenStack Volume Quota', {
+        'name': 'OpenStack Number of Volumes Quota'
+    }),
     ('OpenStack Compute RAM Quota', {
         'name': 'OpenStack Compute RAM Quota (MiB)'
     }),

--- a/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
+++ b/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
@@ -25,6 +25,24 @@ ALLOCATION_ATTRIBUTE_MIGRATIONS = [
     ('OpenShift Limit on RAM Quota', {
         'name': 'OpenShift Limit on RAM Quota (MB)'
     }),
+    ('OpenStack Compute RAM Quota', {
+        'name': 'OpenStack Compute RAM Quota (MiB)'
+    }),
+    ('OpenStack Volume GB Quota', {
+        'name': 'OpenStack Volume Quota (GiB)'
+    }),
+    ('OpenStack Swift Quota in Gigabytes', {
+        'name': 'OpenStack Swift Quota (GiB)'
+    }),
+    ('OpenShift Limit on RAM Quota (MB)', {
+        'name': 'OpenShift Limit on RAM Quota (MiB)'
+    }),
+    ('OpenShift Limit on Ephemeral Storage Quota (GB)', {
+        'name': 'OpenShift Limit on Ephemeral Storage Quota (GiB)'
+    }),  
+    ('OpenShift Request on Storage Quota (GB)', {
+        'name': 'OpenShift Request on Storage Quota (GiB)'
+    }),
 ]
 
 RESOURCE_ATTRIBUTE_MIGRATIONS = [

--- a/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
+++ b/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
@@ -31,9 +31,6 @@ ALLOCATION_ATTRIBUTE_MIGRATIONS = [
     ('OpenStack Volume GB Quota', {
         'name': 'OpenStack Volume Quota (GiB)'
     }),
-    ('OpenStack Swift Quota in Gigabytes', {
-        'name': 'OpenStack Swift Quota (GiB)'
-    }),
     ('OpenShift Limit on RAM Quota (MB)', {
         'name': 'OpenShift Limit on RAM Quota (MiB)'
     }),


### PR DESCRIPTION
Fix for #163

The following Allocation attributes are changed:

- OpenStack Volume Quota --> OpenStack Number of Volumes Quota
- OpenStack Compute RAM Quota --> OpenStack Compute RAM Quota (MiB)
- OpenStack Volume GB Quota --> OpenStack Volume Quota (GiB)
- ~~OpenStack Swift Quota in Gigabytes --> OpenStack Swift Quota (GiB)~~

- OpenShift Limit on RAM Quota (MB) --> OpenShift Limit on RAM Quota (MiB)
- OpenShift Limit on Ephemeral Storage Quota (GB) --> OpenShift Limit on Ephemeral Storage Quota (GiB)
- OpenShift Request on Storage Quota (GB) --> OpenShift Request on Storage Quota (GiB)