### PR TITLE
Allow allocated project name to be displayed in Coldfront UI in the Project detail view

### DIFF
--- a/src/coldfront_plugin_cloud/config.py
+++ b/src/coldfront_plugin_cloud/config.py
@@ -1,7 +1,13 @@
 from coldfront.config.base import INSTALLED_APPS
 from coldfront.config.env import ENV
+from coldfront.config.core import ALLOCATION_ATTRIBUTE_VIEW_LIST
 
 if 'coldfront_plugin_cloud' not in INSTALLED_APPS:
     INSTALLED_APPS += [
         'coldfront_plugin_cloud',
+    ]
+
+if 'Allocated Project Name' not in ALLOCATION_ATTRIBUTE_VIEW_LIST:
+    ALLOCATION_ATTRIBUTE_VIEW_LIST += [
+        'Allocated Project Name'
     ]


### PR DESCRIPTION
Closes nerc-project/coldfront-nerc#118, I've modified the config file to allow the allocated project name to be displayed.