### PR TITLE
Convert Swift quotas from GB to GiB

### DIFF
--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -76,7 +76,7 @@ QUOTA_VOLUMES_GB = 'OpenStack Volume Quota (GiB)'
 
 QUOTA_FLOATING_IPS = 'OpenStack Floating IP Quota'
 
-QUOTA_OBJECT_GB = 'OpenStack Swift Quota in Gigabytes'
+QUOTA_OBJECT_GB = 'OpenStack Swift Quota (GiB)'
 
 QUOTA_GPU = 'OpenStack GPU Quota'
 

--- a/src/coldfront_plugin_cloud/management/commands/convert_swift_quota_to_gib.py
+++ b/src/coldfront_plugin_cloud/management/commands/convert_swift_quota_to_gib.py
@@ -1,0 +1,56 @@
+import logging
+import re
+
+from coldfront_plugin_cloud import attributes
+from coldfront_plugin_cloud import openstack
+from coldfront_plugin_cloud import openshift
+from coldfront_plugin_cloud import utils
+from coldfront_plugin_cloud import tasks
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+from coldfront.core.resource.models import (Resource,
+                                            ResourceType)
+from coldfront.core.allocation.models import (Allocation,
+                                              AllocationStatusChoice,
+                                              AllocationUser)
+from keystoneauth1.exceptions import http
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = """One time command to convert all Swift quotas on all Openstack allocations from
+    GB to GiB. I.e a Swift quota of 1000^2 bytes will now be 1024^2 bytes"""
+
+    def handle(self, *args, **options):
+        openstack_resources = Resource.objects.filter(
+            resource_type=ResourceType.objects.get(
+                name='OpenStack'
+            )
+        )
+        openstack_allocations = Allocation.objects.filter(
+            Q(status=AllocationStatusChoice.objects.get(name='Active')) | 
+            Q(status=AllocationStatusChoice.objects.get(name='Expired')),
+            resources__in=openstack_resources,
+        )
+        for allocation in openstack_allocations:
+            if not (swift_quota := allocation.get_attribute(attributes.QUOTA_OBJECT_GB)):
+                continue
+
+            allocation_str = f'{allocation.pk} of project "{allocation.project.title}"'
+            obj_key = openstack.QUOTA_KEY_MAPPING['object']['keys'][attributes.QUOTA_OBJECT_GB]
+            allocator = openstack.OpenStackResourceAllocator(
+                allocation.resources.first(),
+                allocation
+            )
+
+            project_id = allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID)
+            if not project_id:
+                logger.error(f'{allocation_str} is active but has no Project ID set.')
+                continue
+            payload = {
+                obj_key : swift_quota
+            }
+
+            allocator._set_object_quota(project_id, payload) 

--- a/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
+++ b/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
@@ -43,6 +43,9 @@ ALLOCATION_ATTRIBUTE_MIGRATIONS = [
     ('OpenShift Request on Storage Quota (GB)', {
         'name': 'OpenShift Request on Storage Quota (GiB)'
     }),
+    ('OpenStack Swift Quota in Gigabytes', {
+        'name': 'OpenStack Swift Quota (GiB)'
+    }),
 ]
 
 RESOURCE_ATTRIBUTE_MIGRATIONS = [

--- a/src/coldfront_plugin_cloud/openstack.py
+++ b/src/coldfront_plugin_cloud/openstack.py
@@ -19,7 +19,7 @@ from coldfront_plugin_cloud import attributes, base, utils
 logger = logging.getLogger(__name__)
 
 # 1 GB = 1 000 000 000 B = 10^9 B
-GB_IN_BYTES = 1000000000
+GB_IN_BYTES = 2 ** 30
 
 # Map the attribute name in ColdFront, to the client of the respective
 # service, the version of the API, and the key in the payload.


### PR DESCRIPTION
Closes #162. A one-time command is added which will set the Swift quota of every allocation from GB to GiB. The Swift quota attribute name has been appropriately renamed