### PR TITLE
Fixed billing with decreasing allocation change requests

### DIFF
--- a/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
@@ -178,7 +178,6 @@ class TestCalculateAllocationQuotaHours(base.TestBase):
         )
         self.assertEqual(value, 0)
 
-    @unittest.expectedFailure
     def test_change_request_decrease(self):
         """Test for when a change request decreases the quota"""
         self.resource = self.new_openshift_resource(
@@ -267,7 +266,6 @@ class TestCalculateAllocationQuotaHours(base.TestBase):
         )
         self.assertEqual(value, 384)
 
-    @unittest.expectedFailure
     def test_change_request_decrease_multiple(self):
         """Test for when multiple different change request decreases the quota"""
         self.resource = self.new_openshift_resource(

--- a/src/coldfront_plugin_cloud/utils.py
+++ b/src/coldfront_plugin_cloud/utils.py
@@ -124,7 +124,7 @@ def calculate_quota_unit_hours(allocation: Allocation,
                 # find one that happened just before the next event.
                 cr_created_at = cr.history.first().created
                 if cr.history.first().created <= event_time:
-                    if unbounded_last_event_time and unbounded_last_event_time < cr_created_at:
+                    if unbounded_last_event_time and unbounded_last_event_time > cr_created_at:
                         # But after the unbounded last event time.
                         continue
 


### PR DESCRIPTION
Closes #170. I have introduced 3 test cases for storage billing with change requests (CR), 2 of which are intended to fail. The 3 test cases are:
1. Testing when there is a CR to decrease the quota
2. A CR to increase the quota
3. Multiple CRs to decrease the quota

The test cases involving decreasing the quota should fail, and demonstrates the bug that I will explain below.

From what I read in the billing code, our intention with CRs is that when an allocation's storage quota decreases, this decreased value becomes effective (for billing purposes) when the CR for it is created, not when the CR is approved (or the time at which the quota actually decreased). Due to this [statement](https://github.com/nerc-project/coldfront-plugin-cloud/blob/f7a4dc2f2d212f720fd201bab87971e6c508703d/src/coldfront_plugin_cloud/utils.py#L127), this will not happen, but will lead to a more complicated undesired behavior.

With the current code, the first time the quota decreases, the decreased value becomes effective at the time it is changed. On subsequent instances when the quota decreases, one of two things could happen:
- If the quota is decreased to the same value again, the decreased quota becomes effective from the previous time the quota changed (i.e If the quota was 10GB on May 1st and 5GB on May 10th, the period from May 1st to May 10th would be billed at 5GB)
- Else, the decreased quota becomes effective at time of change.