### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/test-py39-functional-microshift.yaml
+++ b/.github/workflows/test-py39-functional-microshift.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ install_requires =
     python-novaclient
     python-neutronclient
     python-swiftclient
+    requests < 3.0
+    simplejson < 4.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Closes #172 

`simplejson` was not part of the requirements when it should've been. Probably one of our dependencies dropped it, leading to it not being installed through them.

Microshift was being stuck in waiting. I couldn't reproduce the same issue on a 22.04 machine, so I just updated the Ubuntu of the action to 22.04. 