### PR TITLE
Support excluding time intervals during storage invoicing and fixed typo

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -208,7 +208,7 @@ class Command(BaseCommand):
 
             for allocation in openstack_allocations:
                 allocation_str = f'{allocation.pk} of project "{allocation.project.title}"'
-                msg = f'Starting billing for for allocation {allocation_str}.'
+                msg = f'Starting billing for allocation {allocation_str}.'
                 logger.debug(msg)
 
                 process_invoice_row(
@@ -219,7 +219,7 @@ class Command(BaseCommand):
 
             for allocation in openshift_allocations:
                 allocation_str = f'{allocation.pk} of project "{allocation.project.title}"'
-                msg = f'Starting billing for for allocation {allocation_str}.'
+                msg = f'Starting billing for allocation {allocation_str}.'
                 logger.debug(msg)
 
                 process_invoice_row(


### PR DESCRIPTION
Closes #166. Added an optional CLI argument which allows passing in a txt file containing excluded time intervals. Each line in the txt file should contain a date range that we want to exclude from billing, formatted as
 "%Y-%m-%d,%Y-%m-%d". An example line could be "2023-02-01,2023-02-03".

The time period excluded from billing starts from the first second of the start date, and ends on the last second of the end date. This means it is possible for the excluded date range to start and end on the same day.

Also fixed a minor typo.