### PR TITLE
Allow direct communication to Openshift API through `get_federated_user`

### DIFF
--- a/ci/run_functional_tests_openshift.sh
+++ b/ci/run_functional_tests_openshift.sh
@@ -7,6 +7,8 @@ set -xe
 
 export OPENSHIFT_MICROSHIFT_USERNAME="admin"
 export OPENSHIFT_MICROSHIFT_PASSWORD="pass"
+export OPENSHIFT_MICROSHIFT_TOKEN="$(oc create token -n onboarding onboarding-serviceaccount)"
+export OPENSHIFT_MICROSHIFT_VERIFY="false"
 
 if [[ ! "${CI}" == "true" ]]; then
     source /tmp/coldfront_venv/bin/activate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 git+https://github.com/CCI-MOC/nerc-rates@74eb4a7#egg=nerc_rates
 boto3
+kubernetes
+openshift
 coldfront >= 1.1.0
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ python_requires = >=3.8
 install_requires =
     nerc_rates @ git+https://github.com/CCI-MOC/nerc-rates@74eb4a7
     boto3
+    kubernetes
+    openshift
     coldfront >= 1.1.0
     python-cinderclient
     python-keystoneclient

--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -19,6 +19,7 @@ class CloudAllocationAttribute:
 
 
 RESOURCE_AUTH_URL = 'Identity Endpoint URL'
+RESOURCE_IDENTITY_NAME = 'OpenShift Identity Provider Name'
 RESOURCE_ROLE = 'Role for User in Project'
 
 RESOURCE_FEDERATION_PROTOCOL = 'OpenStack Federation Protocol'
@@ -32,6 +33,7 @@ RESOURCE_EULA_URL = "EULA URL"
 
 RESOURCE_ATTRIBUTES = [
     CloudResourceAttribute(name=RESOURCE_AUTH_URL),
+    CloudResourceAttribute(name=RESOURCE_IDENTITY_NAME),
     CloudResourceAttribute(name=RESOURCE_FEDERATION_PROTOCOL),
     CloudResourceAttribute(name=RESOURCE_IDP),
     CloudResourceAttribute(name=RESOURCE_PROJECT_DOMAIN),

--- a/src/coldfront_plugin_cloud/tests/unit/openshift/test_user.py
+++ b/src/coldfront_plugin_cloud/tests/unit/openshift/test_user.py
@@ -1,0 +1,29 @@
+from unittest import mock
+
+from coldfront_plugin_cloud.tests import base
+from coldfront_plugin_cloud.openshift import OpenShiftResourceAllocator
+
+
+class TestOpenshiftUser(base.TestBase):
+    def setUp(self) -> None:
+        mock_resource = mock.Mock()
+        mock_allocation = mock.Mock()
+        self.allocator = OpenShiftResourceAllocator(mock_resource, mock_allocation)
+        self.allocator.id_provider = "fake_idp"
+        self.allocator.k8_client = mock.Mock()
+
+    def test_get_federated_user(self):
+        fake_user = mock.Mock(spec=["to_dict"])
+        fake_user.to_dict.return_value = {"identities": ["fake_idp:fake_user"]}
+        self.allocator.k8_client.resources.get.return_value.get.return_value = fake_user
+
+        output = self.allocator.get_federated_user("fake_user")
+        self.assertEqual(output, {"username": "fake_user"})
+
+    def test_get_federated_user_not_exist(self):
+        fake_user = mock.Mock(spec=["to_dict"])
+        fake_user.to_dict.return_value = {"identities": ["fake_idp:fake_user"]}
+        self.allocator.k8_client.resources.get.return_value.get.return_value = fake_user
+
+        output = self.allocator.get_federated_user("fake_user_2")
+        self.assertEqual(output, None)


### PR DESCRIPTION
Closes #175. As the first step towards merging the account manager into our coldfront cloud plugin, the `get_federated_user` function in the Openshift allocator will now (through several functions) directly call the Openshift API. Much of the functions added are copied from the `moc_openshift` module in the account manager.

Aside from copying some functions,
implementation of this feature also involved:
- A new resource attribute `Identity Name` for the Openshift idp
- A new unit test for the `get_federated_user` function
- Changes to the CI file to enable these new unit tests