### PR TITLE
Avoid interactive prompts during unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/CCI-MOC/nerc-rates@74eb4a7#egg=nerc_rates
 boto3
-coldfront >= 1.0.4
+coldfront >= 1.1.0
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient
 python-memcached==1.59

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ python_requires = >=3.8
 install_requires =
     nerc_rates @ git+https://github.com/CCI-MOC/nerc-rates@74eb4a7
     boto3
-    coldfront >= 1.0.4
+    coldfront >= 1.1.0
     python-cinderclient
     python-keystoneclient
     python-memcached == 1.59

--- a/src/coldfront_plugin_cloud/tests/base.py
+++ b/src/coldfront_plugin_cloud/tests/base.py
@@ -31,7 +31,7 @@ class TestBase(TestCase):
     def setUp(self) -> None:
         # Otherwise output goes to the terminal for every test that is run
         backup, sys.stdout = sys.stdout, open(devnull, 'a')
-        call_command('initial_setup', )
+        call_command('initial_setup', '-f')
         call_command('load_test_data')
         call_command('register_cloud_attributes')
         sys.stdout = backup

--- a/src/coldfront_plugin_cloud/tests/unit/test_attribute_migration.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_attribute_migration.py
@@ -16,7 +16,7 @@ class TestAttributeMigration(base.TestBase):
     def setUp(self) -> None:
         # Run initial setup but do not register the attributes
         backup, sys.stdout = sys.stdout, open(devnull, 'a')
-        call_command('initial_setup', )
+        call_command('initial_setup', '-f')
         call_command('load_test_data')
         sys.stdout = backup
 


### PR DESCRIPTION
Always call `initial_setup` with `-f` option to avoid the "Do you want to
proceed?" interactive prompt.
