### PR TITLE
Fix step name in unit test workflow

### DIFF
--- a/.github/workflows/test-py39-unit.yaml
+++ b/.github/workflows/test-py39-unit.yaml
@@ -22,6 +22,6 @@ jobs:
         run: |
           ./ci/setup.sh
 
-      - name: Run functional tests
+      - name: Run unit tests
         run: |
           ./ci/run_unit_tests.sh


### PR DESCRIPTION
The unit test workflow was reporting "Running functional tests" in the
log, which was confusing.
