### PR TITLE
Add missing shebang (#!) lines

### DIFF
--- a/ci/devstack.sh
+++ b/ci/devstack.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Installs Devstack with the OIDC plugin
 #

--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Installs Microshift on Docker
 #

--- a/ci/run_functional_tests_openshift.sh
+++ b/ci/run_functional_tests_openshift.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Creates the appropriate credentials and runs tests
 #
 # Tests expect the resource to be name Devstack

--- a/ci/run_functional_tests_openstack.sh
+++ b/ci/run_functional_tests_openstack.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Creates the appropriate credentials and runs tests
 #
 # Tests expect the resource to be name Devstack

--- a/ci/run_unit_tests.sh
+++ b/ci/run_unit_tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -xe
 
 if [[ ! "${CI}" == "true" ]]; then

--- a/ci/setup-oc-client.sh
+++ b/ci/setup-oc-client.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -xe
 

--- a/ci/setup-ubuntu.sh
+++ b/ci/setup-ubuntu.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -xe
 

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -xe
 
 # If running on Github actions, don't create a virtualenv


### PR DESCRIPTION
Executable shell scripts should always start with a shebang line
(#!/path/to/shell) specifying which interpreter to use for the script. This
ensures, for example, that in Debian/Ubuntu environments, scripts that
expect Bash semantics are actually using Bash rather than `/bin/sh`.

Scripts that are missing a shebang line will also fail to execute when
executed directly (rather than via a shell):

    >>> import os
    >>> os.execve('./test.sh', ['test.sh'], {})
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    OSError: [Errno 8] Exec format error: './test.sh'
