### PR TITLE
 Support hours when providing outage intervals in billing

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -68,7 +68,7 @@ class InvoiceRow:
 
 
 def datetime_type(v):
-    return pytz.utc.localize(datetime.strptime(v, '%Y-%m-%d'))
+    return pytz.utc.localize(datetime.fromisoformat(v))
 
 
 class Command(BaseCommand):
@@ -97,9 +97,9 @@ class Command(BaseCommand):
                             default='nerc-invoicing')
         parser.add_argument('--upload-to-s3', default=False, action='store_true',
                           help='Upload generated CSV invoice to S3 storage.')
-        parser.add_argument('--excluded-date-ranges', type=str, 
+        parser.add_argument('--excluded-time-ranges', type=str,
                             default=None, nargs='+',
-                            help='List of date ranges excluded from billing')
+                            help='List of time ranges excluded from billing, in ISO format.')
 
     @staticmethod
     def default_start_argument():
@@ -176,9 +176,9 @@ class Command(BaseCommand):
         logger.info(f'Processing invoices for {options["invoice_month"]}.')
         logger.info(f'Interval {options["start"] - options["end"]}.')
 
-        if options["excluded_date_ranges"]:
+        if options["excluded_time_ranges"]:
             excluded_intervals_list = utils.load_excluded_intervals(
-                options["excluded_date_ranges"]
+                options["excluded_time_ranges"]
             )
         else:
             excluded_intervals_list = None

--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -87,9 +87,9 @@ class Command(BaseCommand):
         )
         parser.add_argument('--output', type=str, default='invoices.csv',
                              help='CSV file to write invoices to.')
-        parser.add_argument('--openstack-gb-rate', type=Decimal, required=True,
+        parser.add_argument('--openstack-gb-rate', type=Decimal, required=False,
                             help='Rate for OpenStack Volume and Object GB/hour.')
-        parser.add_argument('--openshift-gb-rate', type=Decimal, required=True,
+        parser.add_argument('--openshift-gb-rate', type=Decimal, required=False,
                             help='Rate for OpenShift GB/hour.')
         parser.add_argument('--s3-endpoint-url', type=str,
                             default='https://s3.us-east-005.backblazeb2.com')
@@ -201,14 +201,20 @@ class Command(BaseCommand):
         )
 
         rates = load_from_url()
-        openstack_storage_rate = openshift_storage_rate = Decimal(
-            rates.get_value_at('Storage GB Rate', options["invoice_month"]))
         
         if options['openstack_gb_rate']:
             openstack_storage_rate = options['openstack_gb_rate']
+        else:
+            openstack_storage_rate = Decimal(
+                rates.get_value_at('Storage GB Rate', options["invoice_month"])
+            )
 
         if options['openshift_gb_rate']:
             openshift_storage_rate = options['openshift_gb_rate']
+        else:
+            openshift_storage_rate = Decimal(
+                rates.get_value_at('Storage GB Rate', options["invoice_month"])
+            )
 
         logger.info(f'Using storage rate {openstack_storage_rate} (Openstack) and '
                     f'{openshift_storage_rate} (Openshift) for {options["invoice_month"]}')

--- a/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
@@ -1,6 +1,7 @@
 import datetime
 import unittest
 import pytz
+import tempfile
 
 import freezegun
 
@@ -9,6 +10,7 @@ from coldfront_plugin_cloud.tests import base
 from coldfront_plugin_cloud import utils
 
 from coldfront.core.allocation import models as allocation_models
+from django.core.management import call_command
 
 
 SECONDS_IN_DAY = 3600 * 24
@@ -41,6 +43,17 @@ class TestCalculateAllocationQuotaHours(base.TestBase):
             pytz.utc.localize(datetime.datetime(2020, 3, 31, 23, 59, 59))
         )
         self.assertEqual(value, 96)
+
+        with tempfile.NamedTemporaryFile() as fp:
+            call_command(
+                'calculate_storage_gb_hours',
+                '--output', fp.name,
+                '--start', '2020-03-01',
+                '--end', '2020-3-31',
+                '--openstack-gb-rate','0.0000087890625',
+                '--openshift-gb-rate','0.0000087890625',
+                '--invoice-month','2020-03'
+            )
 
 
     def test_new_allocation_quota_expired(self):

--- a/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
@@ -391,16 +391,17 @@ class TestCalculateAllocationQuotaHours(base.TestBase):
             ]
 
         # Single interval within active period
-        excluded_intervals = get_excluded_interval_datetime_list(
-            (((2020, 3, 15), (2020, 3, 16)),)
-        )
+        excluded_intervals = [
+            (datetime.datetime(2020, 3, 15, 9, 30, 0),
+             datetime.datetime(2020, 3, 16, 10, 30, 0)),
+        ]
 
         value = utils.get_included_duration(
             datetime.datetime(2020, 3, 15, 0, 0, 0),
             datetime.datetime(2020, 3, 17, 0, 0, 0),
             excluded_intervals
         )
-        self.assertEqual(value, SECONDS_IN_DAY * 1)
+        self.assertEqual(value, SECONDS_IN_DAY * 1 - 3600)
 
         # Interval starts before active period
         excluded_intervals = get_excluded_interval_datetime_list(
@@ -477,14 +478,14 @@ class TestCalculateAllocationQuotaHours(base.TestBase):
         # More than 1 interval
         interval_list = [
             "2023-01-01,2023-01-02",
-            "2023-01-04,2023-01-15",
+            "2023-01-04 09:00:00,2023-01-15 10:00:00",
         ]
         output = utils.load_excluded_intervals(interval_list)
         self.assertEqual(output, [
             [datetime.datetime(2023, 1, 1, 0, 0, 0),
             datetime.datetime(2023, 1, 2, 0, 0, 0)],
-            [datetime.datetime(2023, 1, 4, 0, 0, 0),
-            datetime.datetime(2023, 1, 15, 0, 0, 0)]
+            [datetime.datetime(2023, 1, 4, 9, 0, 0),
+            datetime.datetime(2023, 1, 15, 10, 0, 0)]
         ])
 
     def test_load_excluded_intervals_invalid(self):

--- a/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_calculate_quota_unit_hours.py
@@ -49,10 +49,25 @@ class TestCalculateAllocationQuotaHours(base.TestBase):
                 'calculate_storage_gb_hours',
                 '--output', fp.name,
                 '--start', '2020-03-01',
-                '--end', '2020-3-31',
+                '--end', '2020-03-31',
                 '--openstack-gb-rate','0.0000087890625',
                 '--openshift-gb-rate','0.0000087890625',
                 '--invoice-month','2020-03'
+            )
+
+        # Let's test a complete CLI call including excluded time, while we're at it. This is not for testing
+        # the validity but just the unerrored execution of the complete pipeline.
+        # Tests that verify the correct output are further down in the test file.
+        with tempfile.NamedTemporaryFile() as fp:
+            call_command(
+                'calculate_storage_gb_hours',
+                '--output', fp.name,
+                '--start', '2020-03-01',
+                '--end', '2020-03-31',
+                '--openstack-gb-rate','0.0000087890625',
+                '--openshift-gb-rate','0.0000087890625',
+                '--invoice-month','2020-03',
+                '--excluded-time-ranges', '2020-03-02 00:00:00,2020-03-03 05:00:00'
             )
 
 
@@ -484,8 +499,8 @@ class TestCalculateAllocationQuotaHours(base.TestBase):
         ]
         output = utils.load_excluded_intervals(interval_list)
         self.assertEqual(output, [
-            [datetime.datetime(2023, 1, 1, 0, 0, 0),
-            datetime.datetime(2023, 1, 2, 0, 0, 0)]
+            [pytz.utc.localize(datetime.datetime(2023, 1, 1, 0, 0, 0)),
+            pytz.utc.localize(datetime.datetime(2023, 1, 2, 0, 0, 0))]
         ])
 
         # More than 1 interval
@@ -495,10 +510,10 @@ class TestCalculateAllocationQuotaHours(base.TestBase):
         ]
         output = utils.load_excluded_intervals(interval_list)
         self.assertEqual(output, [
-            [datetime.datetime(2023, 1, 1, 0, 0, 0),
-            datetime.datetime(2023, 1, 2, 0, 0, 0)],
-            [datetime.datetime(2023, 1, 4, 9, 0, 0),
-            datetime.datetime(2023, 1, 15, 10, 0, 0)]
+            [pytz.utc.localize(datetime.datetime(2023, 1, 1, 0, 0, 0)),
+            pytz.utc.localize(datetime.datetime(2023, 1, 2, 0, 0, 0))],
+            [pytz.utc.localize(datetime.datetime(2023, 1, 4, 9, 0, 0)),
+            pytz.utc.localize(datetime.datetime(2023, 1, 15, 10, 0, 0))]
         ])
 
     def test_load_excluded_intervals_invalid(self):

--- a/src/coldfront_plugin_cloud/utils.py
+++ b/src/coldfront_plugin_cloud/utils.py
@@ -185,12 +185,12 @@ def load_excluded_intervals(excluded_interval_arglist):
     excluded_intervals_list = list()
     for interval in excluded_interval_arglist:
         start, end = interval.strip().split(",")
-        start_dt, end_dt = [datetime.datetime.strptime(i, "%Y-%m-%d") for i in [start, end]]
+        start_dt, end_dt = [datetime.datetime.fromisoformat(i) for i in [start, end]]
         assert end_dt > start_dt, f"Interval end date ({end}) is before start date ({start})!"
         excluded_intervals_list.append(
             [
-                datetime.datetime.strptime(start, "%Y-%m-%d"),
-                datetime.datetime.strptime(end, "%Y-%m-%d")
+                datetime.datetime.fromisoformat(start),
+                datetime.datetime.fromisoformat(end)
             ] 
         )
 

--- a/src/coldfront_plugin_cloud/utils.py
+++ b/src/coldfront_plugin_cloud/utils.py
@@ -189,8 +189,8 @@ def load_excluded_intervals(excluded_interval_arglist):
         assert end_dt > start_dt, f"Interval end date ({end}) is before start date ({start})!"
         excluded_intervals_list.append(
             [
-                datetime.datetime.fromisoformat(start),
-                datetime.datetime.fromisoformat(end)
+                pytz.utc.localize(datetime.datetime.fromisoformat(start)),
+                pytz.utc.localize(datetime.datetime.fromisoformat(end))
             ] 
         )
 


### PR DESCRIPTION
This PR has three commits with overall the following changes

- Changes the command line parameter `--exclude-date-ranges` to `--exclude-time-ranges` and its parsing method to ISO.
- Makes `--openshift-gb-rate` and `--openstack-gb-rate` parameters optional. This was required in this PR to allow adding a complete CLI call as part of the unit tests.
- Adds CLI calls in the unit tests for `calculate_storage_gb_hours` with and without the excluded time intervals. There was no tests exercising the above and therefore broken code had slipped in before. This also exposes an issue with the first commit were the time range wasn't properly being parsed.
- Only import `nerc-rates` when storage rate parameters aren't provided through the CLI. `nerc-rates` doesn't seem to work in Python 3.9 which is the current production version and what we're testing for, so this allows the code to work when at least manually giving the values. 

Closes https://github.com/CCI-MOC/invoicing/issues/53
