### PR TITLE
Allows setting quotas of Openshift virtualized GPUs

### DIFF
--- a/.github/workflows/test-py39-functional-microshift.yaml
+++ b/.github/workflows/test-py39-functional-microshift.yaml
@@ -9,7 +9,7 @@ on:
 env:
   PYTHONWARNINGS: ignore
   KUBECONFIG: ${{ github.workspace }}/kubeconfig
-  ACCT_MGT_VERSION: "6012025c247ab25fb2cab3be9ad06080e28713ee"
+  ACCT_MGT_VERSION: "42db8f80962fd355eac1bc80a1894dc6bb824f12"
 
 jobs:
   build:

--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -88,6 +88,8 @@ QUOTA_LIMITS_MEMORY = 'OpenShift Limit on RAM Quota (MiB)'
 QUOTA_LIMITS_EPHEMERAL_STORAGE_GB = 'OpenShift Limit on Ephemeral Storage Quota (GiB)'
 QUOTA_REQUESTS_STORAGE = 'OpenShift Request on Storage Quota (GiB)'
 QUOTA_REQUESTS_GPU = 'OpenShift Request on GPU Quota'
+QUOTA_REQUESTS_GPU_A100_SXM4 = 'OpenShift Request on GPU A100 SXM4 (Only for VM use)'
+QUOTA_REQUESTS_GPU_V100 = 'OpenShift Request on GPU V100 (Only for VM use)'
 QUOTA_PVC = 'OpenShift Persistent Volume Claims Quota'
 
 
@@ -106,5 +108,7 @@ ALLOCATION_QUOTA_ATTRIBUTES = [
     CloudAllocationAttribute(name=QUOTA_LIMITS_EPHEMERAL_STORAGE_GB),
     CloudAllocationAttribute(name=QUOTA_REQUESTS_STORAGE),
     CloudAllocationAttribute(name=QUOTA_REQUESTS_GPU),
+    CloudAllocationAttribute(name=QUOTA_REQUESTS_GPU_A100_SXM4),
+    CloudAllocationAttribute(name=QUOTA_REQUESTS_GPU_V100),
     CloudAllocationAttribute(name=QUOTA_PVC),
 ]

--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -15,6 +15,8 @@ QUOTA_KEY_MAPPING = {
     attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB: lambda x: {":limits.ephemeral-storage": f"{x}Gi"},
     attributes.QUOTA_REQUESTS_STORAGE: lambda x: {":requests.storage": f"{x}Gi"},
     attributes.QUOTA_REQUESTS_GPU: lambda x: {":requests.nvidia.com/gpu": f"{x}"},
+    attributes.QUOTA_REQUESTS_GPU_A100_SXM4: lambda x: {":requests.nvidia.com/A100_SXM4_40GB": f"{x}"},
+    attributes.QUOTA_REQUESTS_GPU_V100: lambda x: {":requests.nvidia.com/GV100GL_Tesla_V100": f"{x}"},
     attributes.QUOTA_PVC: lambda x: {":persistentvolumeclaims": f"{x}"},
 }
 

--- a/src/coldfront_plugin_cloud/tasks.py
+++ b/src/coldfront_plugin_cloud/tasks.py
@@ -35,6 +35,8 @@ UNIT_QUOTA_MULTIPLIERS = {
         attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB: 5,
         attributes.QUOTA_REQUESTS_STORAGE: 20,
         attributes.QUOTA_REQUESTS_GPU: 0,
+        attributes.QUOTA_REQUESTS_GPU_A100_SXM4: 0,
+        attributes.QUOTA_REQUESTS_GPU_V100: 0,
         attributes.QUOTA_PVC: 2
     },
     'esi': {

--- a/src/coldfront_plugin_cloud/tests/functional/openshift/test_allocation.py
+++ b/src/coldfront_plugin_cloud/tests/functional/openshift/test_allocation.py
@@ -121,6 +121,8 @@ class TestAllocation(base.TestBase):
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB), 2 * 5)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_STORAGE), 2 * 20)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_GPU), 2 * 0)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_GPU_A100_SXM4), 2 * 0)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_REQUESTS_GPU_V100), 2 * 0)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_PVC), 2 * 2)
 
         quota = allocator.get_quota(project_id)['Quota']
@@ -133,6 +135,8 @@ class TestAllocation(base.TestBase):
             ":limits.ephemeral-storage": "10Gi",
             ":requests.storage": "40Gi",
             ":requests.nvidia.com/gpu": "0",
+            ":requests.nvidia.com/A100_SXM4_40GB": "0",
+            ":requests.nvidia.com/GV100GL_Tesla_V100": "0",
             ":persistentvolumeclaims": "4",
         })
 
@@ -163,6 +167,8 @@ class TestAllocation(base.TestBase):
             ":limits.ephemeral-storage": "50Gi",
             ":requests.storage": "100Gi",
             ":requests.nvidia.com/gpu": "1",
+            ":requests.nvidia.com/A100_SXM4_40GB": "0",
+            ":requests.nvidia.com/GV100GL_Tesla_V100": "0",
             ":persistentvolumeclaims": "10",
         })
 
@@ -192,6 +198,8 @@ class TestAllocation(base.TestBase):
             ":limits.ephemeral-storage": "10Gi",
             ":requests.storage": "40Gi",
             ":requests.nvidia.com/gpu": "0",
+            ":requests.nvidia.com/A100_SXM4_40GB": "0",
+            ":requests.nvidia.com/GV100GL_Tesla_V100": "0",
             ":persistentvolumeclaims": "4",
         })
 
@@ -211,6 +219,8 @@ class TestAllocation(base.TestBase):
             ":limits.ephemeral-storage": "10Gi",
             ":requests.storage": "40Gi",
             ":requests.nvidia.com/gpu": "0",
+            ":requests.nvidia.com/A100_SXM4_40GB": "0",
+            ":requests.nvidia.com/GV100GL_Tesla_V100": "0",
             ":persistentvolumeclaims": "4",
         })
 


### PR DESCRIPTION
Closes this [issue](https://github.com/nerc-project/operations/issues/820#issue-2669094398), which will allow virtualized GPUs to be requested on Coldfront. 

I have added two new Cloud attributes for the virtualized GPUs.

The `validate_allocations` command has been updated to allow retrospectively adding new quota attributes to old allocations.

Until we finish merging the openshift account manager, I have made another PR there to make sure this feature works for now.