### PR TITLE
Explicitly request type when using `nerc_rates`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/CCI-MOC/nerc-rates@74eb4a7#egg=nerc_rates
+git+https://github.com/CCI-MOC/nerc-rates@33701ed#egg=nerc_rates
 boto3
 kubernetes
 openshift

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ package_dir =
 packages = find:
 python_requires = >=3.11
 install_requires =
-    nerc_rates @ git+https://github.com/CCI-MOC/nerc-rates@74eb4a7
+    nerc_rates @ git+https://github.com/CCI-MOC/nerc-rates@33701ed
     boto3
     kubernetes
     openshift

--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -248,15 +248,15 @@ class Command(BaseCommand):
         if options["openstack_gb_rate"]:
             openstack_storage_rate = options["openstack_gb_rate"]
         else:
-            openstack_storage_rate = Decimal(
-                get_rates().get_value_at("Storage GB Rate", options["invoice_month"])
+            openstack_storage_rate = get_rates().get_value_at(
+                "Storage GB Rate", options["invoice_month"], Decimal
             )
 
         if options["openshift_gb_rate"]:
             openshift_storage_rate = options["openshift_gb_rate"]
         else:
-            openshift_storage_rate = Decimal(
-                get_rates().get_value_at("Storage GB Rate", options["invoice_month"])
+            openshift_storage_rate = get_rates().get_value_at(
+                "Storage GB Rate", options["invoice_month"], Decimal
             )
 
         logger.info(


### PR DESCRIPTION
With the recent update to `nerc_rates` [1] which added type enforcement and requires users of `nerc_rates` to explicitly declare the requested type, our script has been updated to request the appropriate types. This should reduce ambiguity in the values we fetch from nerc_rates

[1] https://github.com/CCI-MOC/nerc-rates/pull/22