### PR TITLE
Remove python 3.9 checks from CI tests 

### DIFF
--- a/.github/workflows/test-functional-microshift.yaml
+++ b/.github/workflows/test-functional-microshift.yaml
@@ -13,9 +13,6 @@ env:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        python-version: [3.9, 3.12]
     runs-on: ubuntu-22.04
 
     steps:
@@ -24,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.12
 
       - name: Fix for "grup-efi-amd64-signed" missing
         run: |

--- a/.github/workflows/test-functional-microstack.yaml
+++ b/.github/workflows/test-functional-microstack.yaml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        python-version: [3.9, 3.12]
     runs-on: ubuntu-22.04
 
     steps:
@@ -19,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.12
 
       - name: Install ColdFront and plugin
         run: |

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        python-version: [3.9, 3.12]
     runs-on: ubuntu-22.04
 
     steps:
@@ -19,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.12
 
       - name: Install ColdFront and plugin
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.11
 install_requires =
     nerc_rates @ git+https://github.com/CCI-MOC/nerc-rates@74eb4a7
     boto3


### PR DESCRIPTION
Closes https://github.com/nerc-project/coldfront-plugin-cloud/issues/217. Removed because of successful tool migration to python 3.12.