### PR TITLE
Remove memcached pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ openshift
 coldfront >= 1.1.0
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient
-python-memcached==1.59
 python-novaclient
 python-neutronclient
 python-swiftclient

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     coldfront >= 1.1.0
     python-cinderclient
     python-keystoneclient
-    python-memcached == 1.59
     python-novaclient
     python-neutronclient
     python-swiftclient

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,6 @@ git+https://github.com/ubccr/coldfront@2e60db247fd9a9b0d1299f1e98f1e4ef5f5c259b#
 freezegun
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient
-python-memcached==1.59
 python-novaclient
 python-neutronclient
 python-swiftclient


### PR DESCRIPTION
Due to ColdFront upstream hard pinning python-memcached, and the OpenStack libraries installing their own version that was a different version, we used to pin memcached to avoid the incompatibility.

We'll now depend on the version that ColdFront pulls in through its own requirements.