### PR TITLE
Support more complex resource names

### DIFF
--- a/src/coldfront_plugin_cloud/tests/unit/test_utils.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_utils.py
@@ -22,3 +22,10 @@ class TestGetSanitizedProjectName(base.TestBase):
         self.assertGreater(len(project_name), max_length)
         new_name = utils.get_unique_project_name(project_name, max_length=max_length)
         self.assertEqual(len(new_name), max_length)
+
+    def test_env_safe_name(self):
+        self.assertEqual(utils.env_safe_name("My Env-Var"), "MY_ENV_VAR")
+        self.assertEqual(utils.env_safe_name("foo@bar!baz"), "FOO_BAR_BAZ")
+        self.assertEqual(utils.env_safe_name(42), "42")
+        self.assertEqual(utils.env_safe_name(None), "NONE")
+        self.assertEqual(utils.env_safe_name("hello"), "HELLO")

--- a/src/coldfront_plugin_cloud/utils.py
+++ b/src/coldfront_plugin_cloud/utils.py
@@ -16,7 +16,7 @@ from coldfront_plugin_cloud import attributes
 
 
 def env_safe_name(name):
-    return name.replace(" ", "_").replace("-", "_").upper()
+    return re.sub(r"[^A-Za-z0-9]", "_", str(name)).upper()
 
 
 def set_attribute_on_allocation(allocation, attribute_type, attribute_value):


### PR DESCRIPTION
closes https://github.com/nerc-project/coldfront-plugin-cloud/issues/48. Replace all non-ascii letters and digits with _. 