### PR TITLE
lower the OpenShift namespace max length from ColdFront Project Title

### DIFF
--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -71,7 +71,7 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
 
     resource_type = "openshift"
 
-    project_name_max_length = 63
+    project_name_max_length = 50
 
     def __init__(self, resource, allocation):
         super().__init__(resource, allocation)


### PR DESCRIPTION
lower the OpenShift namespace from ColdFront Project Title to accommodate with RHOAI Workbench Name