### PR TITLE
Allow direct communication to Openshift RBAC API

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/add_openshift_resource.py
+++ b/src/coldfront_plugin_cloud/management/commands/add_openshift_resource.py
@@ -7,11 +7,18 @@ from coldfront.core.resource.models import (
     ResourceType,
 )
 
-from coldfront_plugin_cloud import attributes
+from coldfront_plugin_cloud import attributes, openshift
 
 
 class Command(BaseCommand):
     help = "Create OpenShift resource"
+
+    @staticmethod
+    def validate_role(role):
+        if role not in openshift.OPENSHIFT_ROLES:
+            raise ValueError(
+                f"Invalid role, {role} is not one of {', '.join(openshift.OPENSHIFT_ROLES)}"
+            )
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -45,6 +52,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        self.validate_role(options["role"])
+
         if options["for_virtualization"]:
             resource_description = "OpenShift Virtualization environment"
             resource_type = "OpenShift Virtualization"

--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -232,12 +232,25 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         logger.info(f"User ({username}) does not exist")
 
     def create_federated_user(self, unique_id):
-        url = f"{self.auth_url}/users/{unique_id}"
-        try:
-            r = self.session.put(url)
-            self.check_response(r)
-        except Conflict:
-            pass
+        user_def = {
+            "metadata": {"name": unique_id},
+            "fullName": unique_id,
+        }
+
+        identity_def = {
+            "providerName": self.id_provider,
+            "providerUserName": unique_id,
+        }
+
+        identity_mapping_def = {
+            "user": {"name": unique_id},
+            "identity": {"name": self.qualified_id_user(unique_id)},
+        }
+
+        self._openshift_create_user(user_def)
+        self._openshift_create_identity(identity_def)
+        self._openshift_create_useridentitymapping(identity_mapping_def)
+        logger.info(f"User {unique_id} successfully created")
 
     def assign_role_on_user(self, username, project_id):
         # /users/<user_name>/projects/<project>/roles/<role>
@@ -291,11 +304,11 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         return self.check_response(r)
 
     def _delete_user(self, username):
-        url = f"{self.auth_url}/users/{username}"
-        r = self.session.delete(url)
-        return self.check_response(r)
+        self._openshift_delete_user(username)
+        self._openshift_delete_identity(username)
+        logger.info(f"User {username} successfully deleted")
 
-    def get_users(self, project_id):
+    def get_users(self, project_id):  # TODO (Quan) This should also replaced
         url = f"{self.auth_url}/projects/{project_id}/users"
         r = self.session.get(url)
         return set(self.check_response(r))
@@ -304,11 +317,42 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         api = self.get_resource_api(API_USER, "User")
         return clean_openshift_metadata(api.get(name=username).to_dict())
 
+    def _openshift_create_user(self, user_def):
+        api = self.get_resource_api(API_USER, "User")
+        try:
+            return clean_openshift_metadata(api.create(body=user_def).to_dict())
+        except kexc.ConflictError:
+            pass
+
+    def _openshift_delete_user(self, username):
+        api = self.get_resource_api(API_USER, "User")
+        return clean_openshift_metadata(api.delete(name=username).to_dict())
+
     def _openshift_get_identity(self, id_user):
         api = self.get_resource_api(API_USER, "Identity")
         return clean_openshift_metadata(
             api.get(name=self.qualified_id_user(id_user)).to_dict()
         )
+
+    def _openshift_create_identity(self, identity_def):
+        api = self.get_resource_api(API_USER, "Identity")
+        try:
+            return clean_openshift_metadata(api.create(body=identity_def).to_dict())
+        except kexc.ConflictError:
+            pass
+
+    def _openshift_delete_identity(self, username):
+        api = self.get_resource_api(API_USER, "Identity")
+        return api.delete(name=self.qualified_id_user(username)).to_dict()
+
+    def _openshift_create_useridentitymapping(self, identity_mapping_def):
+        api = self.get_resource_api(API_USER, "UserIdentityMapping")
+        try:
+            return clean_openshift_metadata(
+                api.create(body=identity_mapping_def).to_dict()
+            )
+        except kexc.ConflictError:
+            pass
 
     def _openshift_user_exists(self, user_name):
         try:

--- a/src/coldfront_plugin_cloud/tests/functional/openshift/test_allocation.py
+++ b/src/coldfront_plugin_cloud/tests/functional/openshift/test_allocation.py
@@ -286,3 +286,33 @@ class TestAllocation(base.TestBase):
         self.assertTrue(
             namespace_dict_labels.items() > openshift.PROJECT_DEFAULT_LABELS.items()
         )
+
+    def test_create_incomplete(self):
+        """Creating a user that only has user, but no identity or mapping should not raise an error."""
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 1)
+        allocator = openshift.OpenShiftResourceAllocator(self.resource, allocation)
+        user_def = {
+            "metadata": {"name": user.username},
+            "fullName": user.username,
+        }
+
+        allocator._openshift_create_user(user_def)
+        self.assertTrue(allocator._openshift_user_exists(user.username))
+        self.assertFalse(allocator._openshift_identity_exists(user.username))
+        self.assertFalse(
+            allocator._openshift_useridentitymapping_exists(
+                user.username, user.username
+            )
+        )
+
+        # Now create identity and mapping, no errors should be raised
+        allocator.get_or_create_federated_user(user.username)
+        self.assertTrue(allocator._openshift_user_exists(user.username))
+        self.assertTrue(allocator._openshift_identity_exists(user.username))
+        self.assertTrue(
+            allocator._openshift_useridentitymapping_exists(
+                user.username, user.username
+            )
+        )

--- a/src/coldfront_plugin_cloud/tests/unit/openshift/test_rbac.py
+++ b/src/coldfront_plugin_cloud/tests/unit/openshift/test_rbac.py
@@ -1,0 +1,134 @@
+from unittest import mock
+
+import kubernetes.dynamic.exceptions as kexc
+
+from coldfront_plugin_cloud.tests import base
+from coldfront_plugin_cloud.openshift import OpenShiftResourceAllocator
+
+
+class TestMocOpenShiftRBAC(base.TestBase):
+    def setUp(self) -> None:
+        mock_resource = mock.Mock()
+        mock_allocation = mock.Mock()
+        self.allocator = OpenShiftResourceAllocator(mock_resource, mock_allocation)
+        self.allocator.id_provider = "fake_idp"
+        self.allocator.k8_client = mock.Mock()
+        self.allocator.member_role_name = "admin"
+
+    def test_user_in_rolebindings_false(self):
+        fake_rb = {
+            "subjects": [
+                {
+                    "kind": "User",
+                    "name": "fake-user-2",
+                }
+            ]
+        }
+        output = self.allocator._user_in_rolebinding("fake-user", fake_rb)
+        self.assertFalse(output)
+
+    def test_user_in_rolebindings_true(self):
+        fake_rb = {
+            "subjects": [
+                {
+                    "kind": "User",
+                    "name": "fake-user",
+                }
+            ]
+        }
+        output = self.allocator._user_in_rolebinding("fake-user", fake_rb)
+        self.assertTrue(output)
+
+    @mock.patch(
+        "coldfront_plugin_cloud.openshift.OpenShiftResourceAllocator._openshift_get_rolebindings"
+    )
+    @mock.patch(
+        "coldfront_plugin_cloud.openshift.OpenShiftResourceAllocator._openshift_update_rolebindings"
+    )
+    def test_add_user_to_role(self, fake_update_rb, fake_get_rb):
+        fake_get_rb.return_value = {
+            "subjects": [],
+        }
+        self.allocator.assign_role_on_user("fake-user", "fake-project")
+        fake_update_rb.assert_called_with(
+            "fake-project", {"subjects": [{"kind": "User", "name": "fake-user"}]}
+        )
+
+    @mock.patch(
+        "coldfront_plugin_cloud.openshift.OpenShiftResourceAllocator._openshift_get_rolebindings"
+    )
+    @mock.patch(
+        "coldfront_plugin_cloud.openshift.OpenShiftResourceAllocator._openshift_create_rolebindings"
+    )
+    def test_add_user_to_role_not_exists(self, fake_create_rb, fake_get_rb):
+        fake_error = kexc.NotFoundError(mock.Mock())
+        fake_get_rb.side_effect = fake_error
+        self.allocator.assign_role_on_user("fake-user", "fake-project")
+        fake_create_rb.assert_called_with("fake-project", "fake-user", "admin")
+
+    @mock.patch(
+        "coldfront_plugin_cloud.openshift.OpenShiftResourceAllocator._openshift_get_rolebindings"
+    )
+    def test_remove_user_from_role(self, fake_get_rb):
+        fake_get_rb.return_value = {
+            "subjects": [{"kind": "User", "name": "fake-user"}],
+        }
+        self.allocator.k8_client.resources.get.return_value.patch.return_value.to_dict.return_value = {}
+        self.allocator.remove_role_from_user("fake-user", "fake-project")
+        self.allocator.k8_client.resources.get.return_value.patch.assert_called_with(
+            body={"subjects": []}, namespace="fake-project"
+        )
+
+    def test_remove_user_from_role_not_exists(self):
+        fake_error = kexc.NotFoundError(mock.Mock())
+        self.allocator.k8_client.resources.get.return_value.get.side_effect = fake_error
+        self.allocator.remove_role_from_user("fake-project", "fake-user")
+        self.allocator.k8_client.resources.get.return_value.patch.assert_not_called()
+
+    def test_get_rolebindings(self):
+        fake_rb = mock.Mock(spec=["to_dict"])
+        fake_rb.to_dict.return_value = {"subjects": []}
+        self.allocator.k8_client.resources.get.return_value.get.return_value = fake_rb
+        res = self.allocator._openshift_get_rolebindings("fake-project", "admin")
+        self.assertEqual(res, fake_rb.to_dict())
+
+    def test_get_rolebindings_no_subjects(self):
+        fake_rb = mock.Mock(spec=["to_dict"])
+        fake_rb.to_dict.return_value = {}
+        self.allocator.k8_client.resources.get.return_value.get.return_value = fake_rb
+        res = self.allocator._openshift_get_rolebindings("fake-project", "admin")
+        self.assertEqual(res, {"subjects": []})
+
+    def test_list_rolebindings(self):
+        fake_rb = mock.Mock(spec=["to_dict"])
+        fake_rb.to_dict.return_value = {
+            "items": ["rb1", "rb2"],
+        }
+        self.allocator.k8_client.resources.get.return_value.get.return_value = fake_rb
+        res = self.allocator._openshift_list_rolebindings("fake-project")
+        self.assertEqual(res, ["rb1", "rb2"])
+
+    def test_list_rolebindings_not_exists(self):
+        fake_error = kexc.NotFoundError(mock.Mock())
+        self.allocator.k8_client.resources.get.return_value.get.side_effect = fake_error
+        res = self.allocator._openshift_list_rolebindings("fake-project")
+        self.assertEqual(res, [])
+
+    def test_create_rolebindings(self):
+        fake_rb = mock.Mock(spec=["to_dict"])
+        fake_rb.to_dict.return_value = {}
+        self.allocator.k8_client.resources.get.return_value.create.return_value = (
+            fake_rb
+        )
+        res = self.allocator._openshift_create_rolebindings(
+            "fake-project", "fake-user", "admin"
+        )
+        self.assertEqual(res, {})
+        self.allocator.k8_client.resources.get.return_value.create.assert_called_with(
+            namespace="fake-project",
+            body={
+                "metadata": {"name": "admin", "namespace": "fake-project"},
+                "subjects": [{"name": "fake-user", "kind": "User"}],
+                "roleRef": {"name": "admin", "kind": "ClusterRole"},
+            },
+        )

--- a/src/coldfront_plugin_cloud/tests/unit/openshift/test_user.py
+++ b/src/coldfront_plugin_cloud/tests/unit/openshift/test_user.py
@@ -37,3 +37,48 @@ class TestOpenshiftUser(base.TestBase):
 
         output = self.allocator.get_federated_user("fake_user_2")
         self.assertEqual(output, None)
+
+    def test_create_federated_user(self):
+        fake_client_output = mock.Mock(spec=["to_dict"])
+        fake_client_output.to_dict.return_value = {}
+        self.allocator.k8_client.resources.get.return_value.create.return_value = (
+            fake_client_output
+        )
+
+        self.allocator.create_federated_user("fake_user_name")
+
+        # Assert called to create user
+        self.allocator.k8_client.resources.get.return_value.create.assert_any_call(
+            body={"metadata": {"name": "fake_user_name"}, "fullName": "fake_user_name"}
+        )
+
+        # Assert called to add identity
+        self.allocator.k8_client.resources.get.return_value.create.assert_any_call(
+            body={
+                "providerName": "fake_idp",
+                "providerUserName": "fake_user_name",
+            }
+        )
+
+        # Assert called to add identity mapping
+        self.allocator.k8_client.resources.get.return_value.create.assert_any_call(
+            body={
+                "user": {"name": "fake_user_name"},
+                "identity": {"name": "fake_idp:fake_user_name"},
+            }
+        )
+
+    def test_delete_user(self):
+        fake_client_output = mock.Mock(spec=["to_dict"])
+        fake_client_output.to_dict.return_value = {}
+        self.allocator.k8_client.resources.get.return_value.delete.return_value = (
+            fake_client_output
+        )
+
+        self.allocator._delete_user("fake_user_name")
+        self.allocator.k8_client.resources.get.return_value.delete.assert_any_call(
+            name="fake_user_name"
+        )
+        self.allocator.k8_client.resources.get.return_value.delete.assert_any_call(
+            name="fake_idp:fake_user_name"
+        )


### PR DESCRIPTION
Closes #186. Dependant on #224, this PR consists of the last commit. After this, #205, #219, and #224 merges, we can remove the dependancy on `openshift-acct-mgt`.