### PR TITLE
Fix `calculate_storage_gb_hours`

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -146,15 +146,15 @@ class Command(BaseCommand):
 
     @staticmethod
     def default_start_argument():
-        d = (datetime.today() - timedelta(days=1)).replace(day=1)
+        d = (datetime.now() - timedelta(days=1)).replace(day=1)
         d = d.replace(hour=0, minute=0, second=0, microsecond=0)
-        return d
+        return pytz.utc.localize(d)
 
     @staticmethod
     def default_end_argument():
-        d = datetime.today()
+        d = datetime.now()
         d = d.replace(hour=0, minute=0, second=0, microsecond=0)
-        return d
+        return pytz.utc.localize(d)
 
     @staticmethod
     def upload_to_s3(s3_endpoint, s3_bucket, file_location, invoice_month):
@@ -310,7 +310,7 @@ class Command(BaseCommand):
             logger.info(f"Uploading to S3 endpoint {options['s3_endpoint_url']}.")
             self.upload_to_s3(
                 options["s3_endpoint_url"],
-                options["s3_bucket"],
+                options["s3_bucket_name"],
                 options["output"],
                 options["invoice_month"],
             )


### PR DESCRIPTION
While testing `calculate_storage_gb_hours`, I realized that the default start and end arguments were not timezone aware, but the django timestamps for event times are. I've added timezone awareness to default start and end date arguments. 

Also fixed `s3-bucket-name` cli argument name.

This is blocking https://github.com/nerc-project/coldfront-nerc/pull/135