### PR TITLE
Migrate to use NESE Storage GB Rate

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
+++ b/src/coldfront_plugin_cloud/management/commands/calculate_storage_gb_hours.py
@@ -252,14 +252,14 @@ class Command(BaseCommand):
             openstack_storage_rate = options["openstack_gb_rate"]
         else:
             openstack_storage_rate = get_rates().get_value_at(
-                "Storage GB Rate", options["invoice_month"], Decimal
+                "NESE Storage GB Rate", options["invoice_month"], Decimal
             )
 
         if options["openshift_gb_rate"]:
             openshift_storage_rate = options["openshift_gb_rate"]
         else:
             openshift_storage_rate = get_rates().get_value_at(
-                "Storage GB Rate", options["invoice_month"], Decimal
+                "NESE Storage GB Rate", options["invoice_month"], Decimal
             )
 
         logger.info(


### PR DESCRIPTION
Closes https://github.com/issues/assigned?issue=CCI-MOC%7Cnerc-rates%7C45. Migrate of our codebases to use the more specific NESE Storage GB Rate rate when referring to storage