### PR TITLE
This lowers the minimum resources that a container must run with.

### DIFF
--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -37,7 +37,7 @@ LIMITRANGE_DEFAULTS = [
         "type": "Container",
         "default": {"cpu": "1", "memory": "4096Mi", "nvidia.com/gpu": "0"},
         "defaultRequest": {"cpu": "500m", "memory": "2048Mi", "nvidia.com/gpu": "0"},
-        "min": {"cpu": "125m", "memory": "256Mi"},
+        "min": {"cpu": "25m", "memory": "32Mi"},
     }
 ]
 


### PR DESCRIPTION
Some containers in the RHOAI application run with 64Mi of memory. The original reason we set these minimum is to prevent people from running containers without any cpu or memory request.