### PR TITLE
Shorten IBM storage attribute name to fit Coldfront's 50 character limit

### DIFF
--- a/src/coldfront_plugin_cloud/attributes.py
+++ b/src/coldfront_plugin_cloud/attributes.py
@@ -89,9 +89,7 @@ QUOTA_LIMITS_CPU = "OpenShift Limit on CPU Quota"
 QUOTA_LIMITS_MEMORY = "OpenShift Limit on RAM Quota (MiB)"
 QUOTA_LIMITS_EPHEMERAL_STORAGE_GB = "OpenShift Limit on Ephemeral Storage Quota (GiB)"
 QUOTA_REQUESTS_NESE_STORAGE = "OpenShift Request on NESE Storage Quota (GiB)"
-QUOTA_REQUESTS_IBM_STORAGE = (
-    "OpenShift Request on IBM Spectrum Scale Storage Quota (GiB)"
-)
+QUOTA_REQUESTS_IBM_STORAGE = "OpenShift Request on IBM Storage Quota (GiB)"
 QUOTA_REQUESTS_GPU = "OpenShift Request on GPU Quota"
 QUOTA_REQUESTS_VM_GPU_A100_SXM4 = "OpenShift Request on GPU A100 SXM4"
 QUOTA_REQUESTS_VM_GPU_V100 = "OpenShift Request on GPU V100"


### PR DESCRIPTION
Coldfront sets a 50 char limit on attribute names. See: https://github.com/ubccr/coldfront/blob/627e9ea957262b3bfcb37e6a19da3d8271a497f1/coldfront/core/allocation/models.py#L425

```$ coldfront register_cloud_attributes                                                                                                                                    10:32:53 [41/41]
/opt/venv/lib/python3.12/site-packages/django_q/conf.py:8: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. R
efrain from using this package or pin to Setuptools<81.
  import pkg_resources
Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/query.py", line 916, in get_or_create
    return self.get(**kwargs), False
           ^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/query.py", line 637, in get
    raise self.model.DoesNotExist(
coldfront.core.allocation.models.AllocationAttributeType.DoesNotExist: AllocationAttributeType matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.StringDataRightTruncation: value too long for type character varying(50)```