### PR TITLE
Integrate nerc-rates for dynamic outage information loading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/CCI-MOC/nerc-rates@33701ed#egg=nerc_rates
+git+https://github.com/CCI-MOC/nerc-rates@5569bba#egg=nerc_rates
 boto3
 kubernetes
 openshift

--- a/src/coldfront_plugin_cloud/utils.py
+++ b/src/coldfront_plugin_cloud/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import math
 import pytz
 import re
@@ -13,6 +14,9 @@ from coldfront.core.allocation.models import (
 )
 
 from coldfront_plugin_cloud import attributes
+
+# Load outages data once per program execution
+_OUTAGES_DATA = None
 
 
 def env_safe_name(name):
@@ -191,6 +195,12 @@ def calculate_quota_unit_hours(
 
 
 def load_excluded_intervals(excluded_interval_arglist):
+    """Parse excluded time ranges from command line arguments.
+
+    :param excluded_interval_arglist: List of time range strings in format "start,end".
+    :return: Sorted list of [start, end] datetime tuples.
+    """
+
     def interval_sort_key(e):
         return e[0]
 
@@ -221,6 +231,27 @@ def load_excluded_intervals(excluded_interval_arglist):
     check_overlapping_intervals(excluded_intervals_list)
 
     return excluded_intervals_list
+
+
+@functools.cache
+def load_outages_from_nerc_rates(
+    start: datetime.datetime, end: datetime.datetime, affected_service: str
+) -> list[tuple[datetime.datetime, datetime.datetime]]:
+    """Load outage intervals from nerc-rates for a given time period and service.
+
+    :param start: Start time for outage search.
+    :param end: End time for outage search.
+    :param affected_service: Name of the affected service (e.g., "stack", "ocp-prod").
+    :return: List of [start, end] datetime tuples representing outages.
+    """
+    global _OUTAGES_DATA
+    if _OUTAGES_DATA is None:
+        from nerc_rates import outages
+
+        _OUTAGES_DATA = outages.load_from_url()
+    return _OUTAGES_DATA.get_outages_during(
+        start.isoformat(), end.isoformat(), affected_service
+    )
 
 
 def _clamp_time(time, min_time, max_time):


### PR DESCRIPTION
- Add load_outages_from_nerc_rates() to fetch outages from nerc-rates repository
- Update calculate_storage_gb_hours to auto-load outages for "stack" and "ocp-prod" services
- Maintain backwards compatibility with --excluded-time-ranges flag
- Add test coverage for nerc-rates integration

Closes #256