### PR TITLE
Bump Coldfront to 1.1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-keystoneclient
 python-novaclient
 python-neutronclient
 python-swiftclient
+pytz

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     python-swiftclient
     requests < 3.0
     simplejson < 4.0
+    pytz
 
 [options.packages.find]
 where = src

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 coverage
-git+https://github.com/ubccr/coldfront@2e60db247fd9a9b0d1299f1e98f1e4ef5f5c259b#egg=coldfront
+git+https://github.com/ubccr/coldfront@v1.1.7#egg=coldfront
 freezegun
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient


### PR DESCRIPTION
Closes #259. Added `pytz` dependency as Coldfront no longer uses it.