### PR TITLE
Set logging level to INFO for management commands

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/convert_swift_quota_to_gib.py
+++ b/src/coldfront_plugin_cloud/management/commands/convert_swift_quota_to_gib.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from coldfront.core.resource.models import Resource, ResourceType
 from coldfront.core.allocation.models import Allocation, AllocationStatusChoice
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/src/coldfront_plugin_cloud/management/commands/count_gpu_usage.py
+++ b/src/coldfront_plugin_cloud/management/commands/count_gpu_usage.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand
 from coldfront.core.resource.models import Resource, ResourceType
 from coldfront.core.allocation.models import Allocation, AllocationStatusChoice
 
-
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/src/coldfront_plugin_cloud/management/commands/list_cloud_allocations.py
+++ b/src/coldfront_plugin_cloud/management/commands/list_cloud_allocations.py
@@ -10,7 +10,7 @@ from coldfront_plugin_cloud import attributes
 from coldfront.core.resource.models import Resource, ResourceType
 from coldfront.core.allocation.models import Allocation, AllocationStatusChoice
 
-
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/src/coldfront_plugin_cloud/management/commands/migrate_fields_of_science.py
+++ b/src/coldfront_plugin_cloud/management/commands/migrate_fields_of_science.py
@@ -6,7 +6,7 @@ from coldfront.core.field_of_science.models import FieldOfScience
 
 import logging
 
-
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -56,7 +56,7 @@ class Command(BaseCommand):
     def _validate_old_fos(mapping_dict):
         for old_fos_name in list(mapping_dict.keys()):
             if not FieldOfScience.objects.filter(description=old_fos_name):
-                logger.warn(f"Old field of science {old_fos_name} does not exist")
+                logger.warning(f"Old field of science {old_fos_name} does not exist")
 
     @staticmethod
     def _create_new_fos(new_fos_set):

--- a/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
+++ b/src/coldfront_plugin_cloud/management/commands/register_cloud_attributes.py
@@ -7,6 +7,7 @@ from coldfront.core.resource import models as resource_models
 
 from coldfront_plugin_cloud import attributes
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/src/coldfront_plugin_cloud/management/commands/validate_allocations.py
+++ b/src/coldfront_plugin_cloud/management/commands/validate_allocations.py
@@ -15,7 +15,7 @@ from coldfront.core.allocation.models import (
 )
 from keystoneauth1.exceptions import http
 
-
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 STATES_TO_VALIDATE = ["Active", "Active (Needs Renewal)"]
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         for coldfront_user in coldfront_users:
             if coldfront_user.user.username not in allocation_users:
                 failed_validation = True
-                logger.warn(
+                logger.warning(
                     f"{coldfront_user.user.username} is not part of {project_id}"
                 )
                 if apply:
@@ -56,7 +56,7 @@ class Command(BaseCommand):
         for allocation_user in allocation_users:
             if allocation_user not in users:
                 failed_validation = True
-                logger.warn(
+                logger.warning(
                     f"{allocation_user} exists in the resource {project_id} but not in coldfront"
                 )
                 if apply:
@@ -97,10 +97,10 @@ class Command(BaseCommand):
         if not isc:
             alloc_str = f'{allocation.pk} of project "{allocation.project.title}"'
             msg = f'Attribute "{attr}" missing on allocation {alloc_str}'
-            logger.warn(msg)
+            logger.warning(msg)
             if apply:
                 utils.set_attribute_on_allocation(allocation, attr, "N/A")
-                logger.warn(f'Attribute "{attr}" added to allocation {alloc_str}')
+                logger.warning(f'Attribute "{attr}" added to allocation {alloc_str}')
 
     def handle(self, *args, **options):
         # Deal with Openstack and ESI resources


### PR DESCRIPTION
Closes #266. As far as I could tell, there isn't a simple way to systematically set the logging level when running management commands to `INFO`. There probably is something I could come up with using [Django logging configurations](https://docs.djangoproject.com/en/5.2/ref/logging/#django-logger), or by creating a base management command class, but I think a more involved solution can be considered when our commands share more in common.