### PR TITLE
Further lower the minimum required CPU and memory

### DIFF
--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -40,7 +40,7 @@ LIMITRANGE_DEFAULTS = [
         "type": "Container",
         "default": {"cpu": "1", "memory": "4096Mi", "nvidia.com/gpu": "0"},
         "defaultRequest": {"cpu": "500m", "memory": "2048Mi", "nvidia.com/gpu": "0"},
-        "min": {"cpu": "25m", "memory": "32Mi"},
+        "min": {"cpu": "1m", "memory": "1Ki"},
     }
 ]
 

--- a/src/coldfront_plugin_cloud/tests/unit/test_openshift_utils.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_openshift_utils.py
@@ -61,5 +61,5 @@ class TestOpenShiftUtils(base.TestBase):
         self.assertTrue(openshift.LimitRangeDifference("foo", None, "bar") in diffs)
         self.assertTrue(openshift.LimitRangeDifference("default,cpu", 1, 2) in diffs)
         self.assertTrue(
-            openshift.LimitRangeDifference("min,memory", 32 * 2**20, None) in diffs
+            openshift.LimitRangeDifference("min,memory", 1 * 2**10, None) in diffs
         )


### PR DESCRIPTION
This sets it to 1 milicore CPU and 1 Kibibyte of memory. I don't think anything can run with just 1 KiB of memory so I think this is quite low at this point.
 
 Is there a reason why this is part of the code and not part of some config file?

closes https://github.com/nerc-project/coldfront-plugin-cloud/issues/258