### PR TITLE
Allow pre-existing OpenShift projects to be managed by Coldfront allocations

### DIFF
--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -304,7 +304,8 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         cloud_quotas = self._openshift_get_resourcequotas(project_id)
         combined_quota = {}
         for cloud_quota in cloud_quotas:
-            combined_quota.update(cloud_quota["spec"]["hard"])
+            if quota_spec := cloud_quota["spec"].get("hard"):
+                combined_quota.update(quota_spec)
 
         return combined_quota
 
@@ -606,7 +607,10 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         resourcequota objects.
         """
 
-        if "resourcequotas" in resource_quota["spec"]["hard"]:
+        if (
+            resource_quota["spec"].get("hard")
+            and "resourcequotas" in resource_quota["spec"]["hard"]
+        ):
             logger.info("waiting for resourcequota quota")
 
             api = self.get_resource_api(API_CORE, "ResourceQuota")


### PR DESCRIPTION
Closes https://github.com/CCI-MOC/ops-issues/issues/1615#issuecomment-3572706859

To use this feature, first create a Coldfront allocation with the appropriate OpenShift resource. Before approving it, use the admin dashboard to add the attributes `Allocated Project ID` and `Allocated Project Name` to the allocation, both assigned to the name of the pre-existing project. Afterwards, approve the allocation, then run `validate_allocations` to populate the quota fields (as well as create various other OpenShift objects) on the allocation and the OpenShift project

Do note, because of how validation is handled for quotas [1], if the pre-existing project already defined its quotas, Coldfront won't overwrite them with the default quotas.

[1] https://github.com/nerc-project/coldfront-plugin-cloud/blob/1b2338d309c7db1c5a418d25fc40169b7edae055/src/coldfront_plugin_cloud/management/commands/validate_allocations.py#L311-L316