### PR TITLE
Update nerc-rates pin to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/CCI-MOC/nerc-rates@5569bba#egg=nerc_rates
+git+https://github.com/CCI-MOC/nerc-rates@v1.0.0#egg=nerc_rates
 boto3
 kubernetes
 openshift

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ package_dir =
 packages = find:
 python_requires = >=3.11
 install_requires =
-    nerc_rates @ git+https://github.com/CCI-MOC/nerc-rates@33701ed
+    nerc_rates @ git+https://github.com/CCI-MOC/nerc-rates@v1.0.0
     boto3
     kubernetes
     openshift


### PR DESCRIPTION
The previous pin had only been updated in requirements.txt, missing setup.cfg therefore an older version of nerc-rates that didn't contain the outages module had been installed.

Closes https://github.com/nerc-project/coldfront-plugin-cloud/issues/273