### PR TITLE
Removes `modelmesh-enabled` label

### DIFF
--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -30,7 +30,6 @@ IGNORED_ATTRIBUTES = [
 
 PROJECT_DEFAULT_LABELS = {
     "opendatahub.io/dashboard": "true",
-    "modelmesh-enabled": "true",
     "nerc.mghpcc.org/allow-unencrypted-routes": "true",
     "nerc.mghpcc.org/project": "true",
 }


### PR DESCRIPTION
Closes https://github.com/nerc-project/operations/issues/1017

The default Openshift label `modelmesh-enabled` has been removed. This label prevents the user from choosing the model-serving option in their RHOAI namespace, which is the desired user behavior.

More details in the linked issue being closed