### PR TITLE
Fix CI due to Docker update

### DIFF
--- a/ci/microshift.sh
+++ b/ci/microshift.sh
@@ -23,7 +23,7 @@ sudo docker run -d --rm --name microshift --privileged \
     quay.io/microshift/microshift-aio:latest
 echo "::endgroup::"
 
-microshift_addr=$(sudo docker inspect microshift -f '{{ .NetworkSettings.IPAddress }}')
+microshift_addr=$(sudo docker inspect microshift --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
 sudo sed -i '/onboarding-onboarding.cluster.local/d' /etc/hosts
 echo "$microshift_addr  onboarding-onboarding.cluster.local" | sudo tee -a /etc/hosts
 


### PR DESCRIPTION
Recently, the microshift CI has been broken because our CI script can't correctly inspect the [IP address ](https://github.com/nerc-project/coldfront-plugin-cloud/actions/runs/21956164426/job/63425892724#step:7:79). Digging a bit further, it seems the error is because the latest version of Docker has deprecated the way we've been inspecting the IP address (`sudo docker inspect microshift -f '{{ .NetworkSettings.IPAddress }}'`), and Github decided to [update Docker in its Action images recently](https://github.com/actions/runner-images/issues/13474).

I've fixed the CI using the inspection method on the [docker documentation](https://docs.docker.com/reference/cli/docker/inspect/#get-an-instances-ip-address)