### PR TITLE
Changed quote char parsing in fetch_daily_billable_usage command

### DIFF
--- a/src/coldfront_plugin_cloud/management/commands/fetch_daily_billable_usage.py
+++ b/src/coldfront_plugin_cloud/management/commands/fetch_daily_billable_usage.py
@@ -194,6 +194,7 @@ class Command(BaseCommand):
             location,
             engine="pyarrow",
             dtype={INVOICE_COLUMN_COST: pandas.ArrowDtype(pyarrow.decimal128(12, 2))},
+            quotechar="|",
         )
         return df.groupby(INVOICE_COLUMN_ALLOCATION_ID)
 

--- a/src/coldfront_plugin_cloud/tests/unit/test_fetch_daily_billable_usage.py
+++ b/src/coldfront_plugin_cloud/tests/unit/test_fetch_daily_billable_usage.py
@@ -14,11 +14,11 @@ from coldfront_plugin_cloud import utils
 
 from django.core.management import call_command
 
-
+# Quote char `|` should be read correctly by fetch command
 TEST_INVOICE = """
 Project - Allocation ID,SU Type,Cost
-test-allocation-1,OpenStack CPU,100.25
-test-allocation-1,OpenStack V100 GPU,500.37
+|test-allocation-1, foo|,OpenStack CPU,100.25
+|test-allocation-1, foo|,OpenStack V100 GPU,500.37
 test-allocation-2,OpenStack CPU,0.25
 """
 
@@ -75,7 +75,9 @@ class TestFetchDailyBillableUsage(base.TestBase):
         invoice = c.load_csv(test_invoice_data)
         mock_load_service_invoice.return_value = invoice
 
-        usage_info = c.get_allocation_usage("Test", "2025-01-11", "test-allocation-1")
+        usage_info = c.get_allocation_usage(
+            "Test", "2025-01-11", "test-allocation-1, foo"
+        )
         usage_info_dict = usage_models.to_dict(usage_info)
 
         self.assertEqual(usage_info_dict["OpenStack CPU"], "100.25")


### PR DESCRIPTION
From a discussion in slack, it was found that the daily cronjob recently stopped running because it failed to load the storage invoice, due to the use of the quote character `|`

This should fix it. Unit test updated