### PR TITLE
Resolve breaking changes by kubernetes package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/CCI-MOC/nerc-rates@v1.0.0#egg=nerc_rates
 boto3>=1.42.6,<2.0
-kubernetes
+kubernetes>=36.0.0
 openshift
 coldfront >= 1.1.0
 pandas>=3.0, <4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ python_requires = >=3.11
 install_requires =
     nerc_rates @ git+https://github.com/CCI-MOC/nerc-rates@v1.0.0
     boto3
-    kubernetes
+    kubernetes>=36.0.0
     openshift
     coldfront >= 1.1.0
     python-cinderclient

--- a/src/coldfront_plugin_cloud/openshift.py
+++ b/src/coldfront_plugin_cloud/openshift.py
@@ -178,8 +178,8 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         openshift_url = self.resource.get_attribute(attributes.RESOURCE_API_URL)
 
         k8_config = kubernetes.client.Configuration()
-        k8_config.api_key["authorization"] = openshift_token
-        k8_config.api_key_prefix["authorization"] = "Bearer"
+        k8_config.api_key["BearerToken"] = openshift_token
+        k8_config.api_key_prefix["BearerToken"] = "Bearer"
         k8_config.host = openshift_url
 
         if self.verify == "false":


### PR DESCRIPTION
First spotted by @jimmysway in #317 

Release v36.0.0 of the Kubernetes python client package introduced a breaking change to how auth is configured [1]

Auth is now configured using `BearerToken` instead of `authorization`

[1] https://github.com/kubernetes-client/python/blob/release-36.0/CHANGELOG.md#breaking-change-from-upgrading-openapi-generator-to-v660